### PR TITLE
extractEnv の改善

### DIFF
--- a/src/server/extract-env.ts
+++ b/src/server/extract-env.ts
@@ -27,7 +27,7 @@ export function extractEnv<K extends readonly string[]>(
     // for-of だとなぜか `key` の型がおかしくなる
     const key: K[number] = keys[i];
     // `keys` から一個ずつ取り出して
-    if (process.env[key] !== undefined) {
+    if (process.env[key] !== undefined && process.env[key] !== '') {
       // 存在したらそれに設定
       env[key] = process.env[key];
     } else if (defaults && defaults[key] !== undefined) {


### PR DESCRIPTION
`.env` の指定を空にしてしまうと空文字列として認識してしまい設定ミスにつながるので, 空文字列を指定が無いものとして扱うようにしてみました.
