### PR TITLE
ci: Markdown に関する CI の修正

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -2,8 +2,6 @@ name: run eslint
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   run_eslint:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -2,8 +2,6 @@ name: run prettier
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   run_prettier:

--- a/.github/workflows/test-else.yml
+++ b/.github/workflows/test-else.yml
@@ -1,0 +1,13 @@
+name: run jest
+
+on:
+  pull_request:
+    paths:
+      - "**.md"
+
+jobs:
+  run_jest:
+    name: jest
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No test required" '


### PR DESCRIPTION
Markdown に対しても ESLint を使用しているので, Markdown を編集したときも CI を実行する動作が正しくなりました.

テストの場合は Markdown に対して実行することが無いのでジェネリックワークフローを用意して常に CI が通るようにしました.
