### PR TITLE
feat: 国勢調査に人間の数の項目名を追加、改善

### DIFF
--- a/src/service/kokusei-chousa.test.ts
+++ b/src/service/kokusei-chousa.test.ts
@@ -21,12 +21,12 @@ test('use case of kokusei-chousa', async () => {
           title: '***†只今の限界開発鯖の人口†***',
           fields: [
             {
-              name: '人類の数',
+              name: '人間+Bot',
               value: `150人`,
               inline: true
             },
             {
-              name: '人間の数',
+              name: '人類の数',
               value: '100人',
               inline: true
             },

--- a/src/service/kokusei-chousa.test.ts
+++ b/src/service/kokusei-chousa.test.ts
@@ -4,7 +4,7 @@ import { createMockMessage } from './command-message';
 test('use case of kokusei-chousa', async () => {
   const responder = new KokuseiChousa({
     allMemberCount(): Promise<number> {
-      return Promise.resolve(100);
+      return Promise.resolve(150);
     },
     botMemberCount(): Promise<number> {
       return Promise.resolve(50);
@@ -22,11 +22,16 @@ test('use case of kokusei-chousa', async () => {
           fields: [
             {
               name: '人類の数',
-              value: `100人`,
+              value: `150人`,
               inline: true
             },
-            { name: 'Bot数', value: `50人`, inline: true },
-            { name: 'Bot率', value: '50.000%', inline: true }
+            {
+              name: '人間の数',
+              value: '100人',
+              inline: true
+            },
+            { name: 'Botの数', value: `50人`, inline: true },
+            { name: 'Bot率', value: '33.333%' }
           ]
         });
         return Promise.resolve();

--- a/src/service/kokusei-chousa.ts
+++ b/src/service/kokusei-chousa.ts
@@ -44,12 +44,12 @@ export class KokuseiChousa implements CommandResponder {
       title: '***†只今の限界開発鯖の人口†***',
       fields: [
         {
-          name: '人類の数',
+          name: '人間+Bot',
           value: `${allMemberCount}人`,
           inline: true
         },
         {
-          name: '人間の数',
+          name: '人類の数',
           value: `${peopleCount}人`,
           inline: true
         },

--- a/src/service/kokusei-chousa.ts
+++ b/src/service/kokusei-chousa.ts
@@ -37,6 +37,7 @@ export class KokuseiChousa implements CommandResponder {
 
     const botMemberCount = await this.stats.botMemberCount();
     const allMemberCount = await this.stats.allMemberCount();
+    const peopleCount = allMemberCount - botMemberCount;
     const botRate = (botMemberCount / allMemberCount) * 100;
 
     await message.reply({
@@ -47,8 +48,13 @@ export class KokuseiChousa implements CommandResponder {
           value: `${allMemberCount}人`,
           inline: true
         },
+        {
+          name: '人間の数',
+          value: `${peopleCount}人`,
+          inline: true
+        },
         { name: 'Bot数', value: `${botMemberCount}人`, inline: true },
-        { name: 'Bot率', value: botRate.toFixed(3) + '%', inline: true }
+        { name: 'Bot率', value: botRate.toFixed(3) + '%' }
       ]
     });
   }

--- a/src/service/kokusei-chousa.ts
+++ b/src/service/kokusei-chousa.ts
@@ -53,7 +53,7 @@ export class KokuseiChousa implements CommandResponder {
           value: `${peopleCount}人`,
           inline: true
         },
-        { name: 'Bot数', value: `${botMemberCount}人`, inline: true },
+        { name: 'Botの数', value: `${botMemberCount}人`, inline: true },
         { name: 'Bot率', value: botRate.toFixed(3) + '%' }
       ]
     });


### PR DESCRIPTION
- 国勢調査に **人間の数**(BOTユーザではない一般ユーザー) を追加
- 国勢調査の項目名を一部修正
- 国勢調査のEmbedの値の位置を改善