### PR TITLE
fix: `judge` コマンドのケース数に上限を追加

### DIFF
--- a/src/service/judgement.test.ts
+++ b/src/service/judgement.test.ts
@@ -67,3 +67,70 @@ test('use case of judge', async () => {
     description: `1 / 1 WA`
   });
 });
+
+test('max number of cases', async () => {
+  const responder = new JudgementCommand({
+    sleep: () => Promise.resolve(),
+    uniform: () => 1
+  });
+
+  await responder.on(
+    'CREATE',
+    createMockMessage(
+      {
+        args: ['jd', '1']
+      },
+      (embed) => {
+        expect(embed).toStrictEqual({
+          title: '***†HARACHO ONLINE JUDGEMENT SYSTEM†***',
+          description: '0 / 1 WJ'
+        });
+        return Promise.resolve({ edit: () => Promise.resolve() });
+      }
+    )
+  );
+  await responder.on(
+    'CREATE',
+    createMockMessage(
+      {
+        args: ['jd', '64']
+      },
+      (embed) => {
+        expect(embed).toStrictEqual({
+          title: '***†HARACHO ONLINE JUDGEMENT SYSTEM†***',
+          description: '0 / 64 WJ'
+        });
+        return Promise.resolve({ edit: () => Promise.resolve() });
+      }
+    )
+  );
+
+  await responder.on(
+    'CREATE',
+    createMockMessage(
+      {
+        args: ['jd', '0']
+      },
+      (embed) => {
+        expect(embed).toStrictEqual({
+          title: '回数の指定が 1 以上 64 以下の整数じゃないよ。'
+        });
+        return Promise.resolve({ edit: () => Promise.resolve() });
+      }
+    )
+  );
+  await responder.on(
+    'CREATE',
+    createMockMessage(
+      {
+        args: ['jd', '65']
+      },
+      (embed) => {
+        expect(embed).toStrictEqual({
+          title: '回数の指定が 1 以上 64 以下の整数じゃないよ。'
+        });
+        return Promise.resolve({ edit: () => Promise.resolve() });
+      }
+    )
+  );
+});

--- a/src/service/judgement.ts
+++ b/src/service/judgement.ts
@@ -48,7 +48,7 @@ export class JudgementCommand implements CommandResponder {
     argsFormat: [
       {
         name: 'テストケースの数',
-        description: '判定のアニメーションに使うテストケースの数',
+        description: '判定のアニメーションに使うテストケースの数、最大値は 64',
         defaultValue: '5'
       },
       {
@@ -72,9 +72,9 @@ export class JudgementCommand implements CommandResponder {
       return;
     }
     const count = parseInt(countArg, 10);
-    if (Number.isNaN(count) || count <= 0) {
+    if (Number.isNaN(count) || count <= 0 || 64 < count) {
       await message.reply({
-        title: '回数の指定が正の整数じゃないよ。'
+        title: '回数の指定が 1 以上 64 以下の整数じゃないよ。'
       });
       return;
     }


### PR DESCRIPTION
1 以上 64 以下のケース数のみ指定できるようにしました
