### PR TITLE
fix: CodeQL AnalysisがTypeScriptに対してのみ走るように

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'typescript' ]
+        language: [ 'typescript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 


### PR DESCRIPTION
https://github.com/approvers/OreOreBot2/runs/6186607446

![image](https://user-images.githubusercontent.com/82575685/165426749-853422b6-21c9-48a9-b2bd-9c8734efadeb.png)

Analysis結果が `Not found` になるのを直します