### PR TITLE
docs: Issue / Pull Request Templateの修正

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -116,3 +116,27 @@ docs: correct spelling of CHANGELOG
 ```
 
 詳しくは [Conventional Commits](https://conventionalcommits.org/) を参照してください。
+
+## Issue
+
+不具合報告や機能の要望、立案を行う際は [Issue](https://github.com/approvers/OreOreBot2/issues/new/choose) を利用してください。
+
+OreOreBot2 では Issue Template を用意しています。
+
+- [Bug-report](https://github.com/approvers/OreOreBot2/issues/new?assignees=&labels=bug&template=bug-report.md&title=)
+  - OreOreBot2 の不具合を報告する際に使用してください。
+- [Feature-request](https://github.com/approvers/OreOreBot2/issues/new?assignees=&labels=enhancement&template=feature-request.md&title=feat%3A+)
+  - OreOreBot2 の新機能立案などを行う際に使用してください。
+- [Custom-Issue](https://github.com/approvers/OreOreBot2/issues/new?assignees=&labels=&template=custom-issue.md&title=)
+  - 上記に当てはまらない内容の Issue を立てたいときに使用してください。
+  - 完全カスタマイズの Issue を作る際もこれを使用してください。
+- [Discord](https://support.discord.com/hc/ja/requests/new?ticket_form_id=360006586013)
+  - Discord の不具合は言わずもがな **Discord 運営チーム**　に報告してください。
+
+## Pull Request
+
+- Pull Request のタイトルは Conventional Commit の型を使用して作成してください。
+  - 例: `feat: えぬ留年構文ジェネレータの実装`, `fix: えぬが留年しない問題の修正`
+- Pull Request 作成時は Issue と同様テンプレートが用意されているので詳細情報の記載をお願いします。
+- draft などぜひ有効活用してください。
+  - 一度作成しても Assign の欄に `Still in progress? Convert to draft` とわかりにくいですがこれを利用することで途中からでも draft に設定できます。

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,18 +6,18 @@ labels: bug
 assignees: ''
 ---
 
-**Describe the bug (説明)**
+### Describe the bug (説明)
 
-**To Reproduce (再現方法)**
+### To Reproduce (再現方法)
 
-**Expected behavior (期待される動作)**
+### Expected behavior (期待される動作)
 
-**Screenshots (スクリーンショット)**
+### Screenshots (スクリーンショット)
 
-**Client Information (クライアント情報)**
+### Client Information (クライアント情報)
 
 - OS:
 - Client[e.g. Stable, Canary]:
 - Version: <!-- Discordの設定画面から確認できます -->
 
-**Additional context (追加情報)**
+### Additional context (追加情報)

--- a/.github/ISSUE_TEMPLATE/custom-issue.md
+++ b/.github/ISSUE_TEMPLATE/custom-issue.md
@@ -6,16 +6,16 @@ labels: ''
 assignees: ''
 ---
 
-**Corresponding Passage (該当箇所)**
+### Corresponding Passage (該当箇所)
 
 <!-- 現行のコード/ドキュメントのどのファイルの何行目にどのような問題があるのか。GitHubの permalink で指定してくださると嬉しいです。 -->
 
-**Problem Analysis (問題の分析)**
+### Problem Analysis (問題の分析)
 
 <!-- どのような問題があったのか。 5段階程度まで原因を遡るとなお良いです。 -->
 
-**Problem Solution (問題の解決)**
+### Problem Solution (問題の解決)
 
 <!-- どんな課題が解決されればこのIssueをCloseできるのか。チェックリスト形式だと嬉しいです。 -->
 
-**Additional Information (追加情報)**
+### Additional Information (追加情報)

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -6,8 +6,8 @@ labels: enhancement
 assignees: ''
 ---
 
-**Describe the solution you'd like (要望の内容)**
+### Describe the solution you'd like (要望の内容)
 
-**Describe alternatives you've considered (代替え案)**
+### Describe alternatives you've considered (代替え案)
 
-**Additional context (追加情報)**
+### Additional context (追加情報)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,18 @@
 **Issue:** #
 
-**Type of Change:**
+### Type of Change:
 
 <!--
     案を実現するためにどういうタイプの変更を行ったのか
     e.g. 修正(fix), 新規追加(feat), 破壊的変更　など
 -->
 
-**Cause of the Problem (問題の原因)**
+### Cause of the Problem (問題の原因)
 
-**Dealing with Problems (問題への対処)**
+### Dealing with Problems (問題への対処)
 
 <!-- 問題対処の方法についての複数の案とどれを採用したのか -->
 
-**Details of implementation (実施内容)**
+### Details of implementation (実施内容)
 
-**Additional Information (追加情報)**
+### Additional Information (追加情報)


### PR DESCRIPTION
**Issue:** #165 

**Type of Change:**

- テンプレートの各項目をヘッダー(`h3`)に変更
- Issue, Pull Requestの貢献について追記

**Cause of the Problem (問題の原因)**

現在の各テンプレートは項目と内容がごっちゃになりがちでわかりにくい問題がありました。

**Additional Information (追加情報)**

ものすごく小さい変更を該当PRで済ませました: 

- `README.md` であった虚偽の文章を削除
- ~~Herokuの設定ファイルを削除~~
- ~~スクリプトコマンド `yarn build`(コンパイル) を `yarn compile` に修正~~