### PR TITLE
ci: CodeQLの問題を修正

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+paths:
+  - src
+paths-ignore:
+  - '**.md'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
 paths:
   - src
 paths-ignore:
-  - '/**/*.md'
+  - '**/*.md'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
 paths:
   - src
 paths-ignore:
-  - '**.md'
+  - '*.md'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
 paths:
   - src
 paths-ignore:
-  - '*.md'
+  - '/**/*.md'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,8 +14,6 @@ name: run codeql analysis
 on:
   push:
   pull_request:
-    paths-ignore:
-      - '**.md'
   schedule:
     - cron: '34 5 * * 1'
 
@@ -67,3 +65,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+      with:
+        config-file: ./.github/codeql/codeql-config.yml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,8 +22,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
       security-events: write
 
     strategy:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,8 +13,6 @@ name: run codeql analysis
 
 on:
   push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Check CodeQL Analysis Config
       uses: github/codeql-action/init@v2
       with:
-        config-file: ./github/codeql/codeql-config.yml
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,11 @@ name: run codeql analysis
 
 on:
   push:
+    branches:
+     - main
   pull_request:
+    branches:
+     - main
   schedule:
     - cron: '34 5 * * 1'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,4 +67,4 @@ jobs:
         config-file: ./github/codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,7 +61,10 @@ jobs:
     #   make bootstrap
     #   make release
 
+    - name: Check CodeQL Analysis Config
+      uses: github/codeql-action/init@v2
+      with:
+        config-file: ./github/codeql/codeql-config.yml
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-      with:
-        config-file: ./.github/codeql/codeql-config.yml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,9 +37,10 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
@@ -61,10 +62,6 @@ jobs:
     #   make bootstrap
     #   make release
 
-    - name: Check CodeQL Analysis Config
-      uses: github/codeql-action/init@v2
-      with:
-        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
**Issue:** No Issue

### Type of Change:

CIの修正

### Cause of the Problem (問題の原因)

CodeQL CIで以下の警告が報告されていた:

> 1 issue was detected with this workflow: Using `on.push.paths-ignore` can prevent Code Scanning annotating new alerts in your pull requests.

これについて https://github.com/github/codeql-action/issues/283 ・ [Code Securityに関するGitHub Docs](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-a-custom-configuration-file) を見てみると GitHub Actions の設定ファイル(`workflows/` 配下) でパスの除外(paths-ignore)を行うのはベストプラクティスではないことがわかった

### Dealing with Problems (問題への対処)

https://github.com/github/codeql-action/issues/283 を見ると [codeql-action](https://github.com/github/codeql-action) では独自の設定ファイルがあり、それを `jobs.steps.with.config-file` にパスとして渡してあげることで対処

### Details of implementation (実施内容)

- GitHub Actionsの設定ファイルから `on.push.paths-ignore` と `on.pull_request.paths-ignore` を削除
- 独自の設定ファイル ( `codeql-config.yml` ) を追加
　- `src/` 配下にあるファイルに対して実行されるように
　- Markdownの変更には実行されないように