### PR TITLE
ci: リリース CI の実行条件を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*.*.*"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
**Issue:** #140

### Type of Change:

Ci ワークフローの修正

### Cause of the Problem (問題の原因)

リリースをあらゆる main への push にしていたためいくつかの弊害があった

### Dealing with Problems (問題への対処)

リリース CI の実行条件を, `v*.*.*` の形式のタグが push されたときに変更しました.

### Additional Information (追加情報)

これ以降, リリースするには以下のようにコマンドを実行するか, ほか git クライアントでタグを作成 & push することになります.

```sh
# バージョン 1.2.3 の場合
git tag v1.2.3
git push origin v1.2.3
```
