### PR TITLE
ci: リリース CI の実行条件を schedule に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 on:
+  push:
+    tags:
+      - "v*.*.*"
   schedule:
     #        +---------------- minute (0 - 59)
     #        | +------------- hour (0 - 23)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
 name: Release
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*.*.*"
+  schedule:
+    #        +---------------- minute (0 - 59)
+    #        | +------------- hour (0 - 23)
+    #        | | +---------- day of month (1 - 31)
+    #        | | | +------- month (1 - 12)
+    #        | | | | +---- day of week (0 - 6) (Sunday=0 or 7)
+    #        | | | | |
+    - cron: "0 3 * * 6" # At 12:00 on Saturday (JST)
 
 jobs:
   release:


### PR DESCRIPTION
### Type of Change:

CI ワークフローの修正

### Details of implementation (実施内容)

リリース CI の実行条件を `cron` で毎週土曜日の正午 (YML 上の表記は UTC であることに注意) に変更しました. これによりデフォルトブランチの最後のコミットを用いて, 毎週リリースが自動作成されます.

### Additional Information (追加情報)

`semantic-release` は差分を検知して変更が無いときはリリースを作成しないため, 空のリリースが作られることはありません.
