### PR TITLE
[WIP] ci: Labelの自動同期CIの追加

### DIFF
--- a/.github/workflows/auto-label-sync.yml
+++ b/.github/workflows/auto-label-sync.yml
@@ -1,1 +1,25 @@
-name: Aut
+name: Auto label sync
+
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/label.yml'
+  workflow_dispatch:
+
+jobs:
+  label-sync:
+    name: Labeler
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Run Label Sync
+        uses: crazy-max/ghaction-github-labeler@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-label-sync.yml
+++ b/.github/workflows/auto-label-sync.yml
@@ -1,0 +1,1 @@
+name: Aut

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,4 +1,4 @@
-name: "Pull Request Labeler"
+name: auto labeler
 on:
   - pull_request_target
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: run codeql analysis
 
 on:
@@ -31,41 +20,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'typescript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        language: [ 'typescript' ] # https://git.io/codeql-language-support
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
**Issue:** #

### Type of Change:

feat(ci): `.github/workflows/auto-label-sync.yml`
----
fix(ci): `.github/workflows/auto-labeler.yml`
fix(ci): `.github/workflows/codeql-analysis.yml`

### Details of implementation (実施内容)

approvers/OreOreBot2 のLabelを自動で同期するCIを追加します。これにより、メンテナではないユーザーもラベルの追加をpull requestとして提出できるようになります。

CI関連のIssueも含んでいます。

----

- [ ] Labelの自動同期CIの追加
- [ ] #192 
- [ ] #191 

### Additional Information (追加情報)

- 下書きを意味する `WIP` のラベルを追加します。
- CodeQL Analysisの `name` からダブルクォーテーションを削除し、統一化しました。
