### PR TITLE
fix: dousureba も dousurya として扱うように修正

### DIFF
--- a/src/service/meme.test.ts
+++ b/src/service/meme.test.ts
@@ -58,6 +58,20 @@ test('use case of dousurya', async () => {
       }
     )
   );
+  await responder.on(
+    'CREATE',
+    createMockMessage(
+      {
+        args: ['dousureba', 'こるく']
+      },
+      (message) => {
+        expect(message).toStrictEqual({
+          description: `限界みたいな鯖に住んでるこるくはどうすりゃいいですか？`
+        });
+        return Promise.resolve();
+      }
+    )
+  );
 });
 
 test('use case of takopi', async () => {

--- a/src/service/meme/dousurya.ts
+++ b/src/service/meme/dousurya.ts
@@ -1,7 +1,7 @@
 import type { MemeTemplate } from '../../model/meme-template';
 
 export const dousurya: MemeTemplate<never, never> = {
-  commandNames: ['dousurya'],
+  commandNames: ['dousurya', 'dousureba'],
   description: '限界みたいな鯖に住んでる〜はどうすりゃいいですか？',
   flagsKeys: [],
   optionsKeys: [],


### PR DESCRIPTION
### Type of Change:

潜在した破壊的変更の修正

### Details of implementation (実施内容)

#210 にて `dousureba` コマンドを `dousurya` に変更していましたが, その際に `dousureba` への対応を削除していたため破壊的変更となっていました. `dousurya` に加えて `dousureba` でも反応するように修正し, 破壊的変更を解消します.
