### PR TITLE
ci: リリース CI のタグによる実行条件を `latest` に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "latest"
   schedule:
     #        +---------------- minute (0 - 59)
     #        | +------------- hour (0 - 23)


### PR DESCRIPTION
### Type of Change:

CI の修正

### Cause of the Problem (問題の原因)

`v*.*.*` の形式のタグを push する場合でも CI が動作するようにしていたが, この場合に CI でもタグを作成しようとしてしまうためリリースに失敗していた.

### Dealing with Problems (問題への対処)

`semantic-release` の設定を変更して, 手動作成したタグをそのまま利用してリリースできるようにすることを考えた. しかし, この場合だと間違ったバージョンのタグを作成した場合に混乱が生じる. それだけでなく, 正しいバージョンのタグを発行する手間が生じる.

### Details of implementation (実施内容)

`latest` タグを `push` したときに実行するように条件を変更した. これにより, どの場合でも `semantic-release` によって正しいバージョンのタグとリリースが生成される.

### Additional Information (追加情報)

この方法では, `latest` タグが既に存在している場合に以下の手順で上書きしなければならない.

1. このタグをローカルで更新する. `git tag -f latest`
2. タグを forced-push する. `git push -f origin latest`
