### PR TITLE
ci: releaserc の branches に latest タグの ref によるものを追加

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,6 +5,7 @@
     "@semantic-release/github"
   ],
   "branches": [
-    "main"
+    "main",
+    "refs/tags/latest"
   ]
 }


### PR DESCRIPTION
### Type of Change:

CI の設定の修正

### Details of implementation (実施内容)

実際に `latest` タグを push してみたところ, `semantic-release` から以下のように出力されました.

```
[1:41:02 PM] [semantic-release] › ℹ  This test run was triggered on the branch refs/tags/latest, while semantic-release is configured to only publish from main, therefore a new version won’t be published.
```

`branches` に `main` のみを指定していたため, ブランチが違うと認識されリリースされなかったようです. そこで `branches` に `refs/tags/latest` を追加し, `latest` タグの push で動作するようにしてみました.

### Additional Information (追加情報)

[似たことをさせようとする提案の Issue](https://github.com/semantic-release/semantic-release/issues/1389) によると, tag を push したときにリリースさせるような使用方法はサポート対象外のようです.
