### PR TITLE
ci: デプロイのCIを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-on: push
+on: release
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
-          port: ${{ secrets.SSH_PORT }}
+          port: 22
           script: |
             cd OreOreBot2
             git pull

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy
+
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install SSH Key for Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            cd OreOreBot2
+            git pull
+            yarn
+            yarn build
+            yarn start


### PR DESCRIPTION
**Issue:** No Issue

### Type of Change:

add: `.github/workflows/deploy.yml`

### Details of implementation (実施内容)

リリース時に稼働サーバーに自動的にssh接続を行い、一連の更新作業を行うデプロイCIを追加します。

SSH鍵などの機密情報すべてシークレットとして保存しており、今後これらのファイルにアクセスするようなワークフローが出てきた場合は @Meru92 のレビューが必須になるような設定になっています。

参考: 
- https://docs.github.com/ja/developers/overview/managing-deploy-keys
- https://docs.github.com/ja/actions/security-guides/security-hardening-for-github-actions
