### PR TITLE
feat: `typo by` コマンドの追加

### DIFF
--- a/src/service/typo-record.test.ts
+++ b/src/service/typo-record.test.ts
@@ -109,6 +109,31 @@ test('show all typos', async () => {
   runner.killAll();
 });
 
+test('invalid user id', async () => {
+  const clock = new MockClock(new Date(0));
+  const db = new InMemoryTypoRepository();
+  const runner = new ScheduleRunner(clock);
+
+  const responder = new TypoReporter(db, clock, runner);
+  await responder.on(
+    'CREATE',
+    createMockMessage(
+      {
+        args: ['typo', 'by', 'hoge']
+      },
+      (message) => {
+        expect(message).toStrictEqual({
+          title: '入力形式エラー',
+          description: 'ユーザ ID は整数を入力してね'
+        });
+        return Promise.resolve();
+      }
+    )
+  );
+
+  runner.killAll();
+});
+
 test('must not reply', async () => {
   const clock = new MockClock(new Date(0));
   const db = new InMemoryTypoRepository();

--- a/src/service/typo-record.ts
+++ b/src/service/typo-record.ts
@@ -109,6 +109,8 @@ const typoRecordResetTask =
     return next6OClock(clock);
   };
 
+const DIGITS = /^[0-9]+$/;
+
 /**
  * `typo` コマンドで今日の Typo 一覧を返信する。
  *
@@ -160,6 +162,13 @@ export class TypoReporter implements CommandResponder {
         await message.reply({
           title: '入力形式エラー',
           description: '`typo by <id>` の形式で入力してね'
+        });
+        return;
+      }
+      if (!DIGITS.test(userId)) {
+        await message.reply({
+          title: '入力形式エラー',
+          description: 'ユーザ ID は整数を入力してね'
         });
         return;
       }

--- a/src/service/typo-record.ts
+++ b/src/service/typo-record.ts
@@ -121,7 +121,13 @@ export class TypoReporter implements CommandResponder {
     title: '今日のTypo',
     description: '「〜だカス」をTypoとして一日間記録するよ',
     commandName: ['typo'],
-    argsFormat: []
+    argsFormat: [
+      {
+        name: 'by',
+        description:
+          'この後にユーザ ID を入れると, そのユーザ ID の今日の Typo を表示するよ'
+      }
+    ]
   };
 
   constructor(
@@ -141,14 +147,45 @@ export class TypoReporter implements CommandResponder {
       return;
     }
     const { senderId, senderName, args } = message;
-    if (args.length !== 1 || args[0] !== 'typo') {
+    if (args.length < 1 || args[0] !== 'typo') {
       return;
     }
-    const description = (await this.repo.allTyposByDate(senderId))
-      .map((typo) => `- ${typo}`)
-      .join('\n');
+    if (args.length === 1) {
+      await this.replyTypos(message, senderId, senderName);
+      return;
+    }
+    if (2 <= args.length && args[1] === 'by') {
+      const userId: string | undefined = args[2];
+      if (!userId) {
+        await message.reply({
+          title: '入力形式エラー',
+          description: '`typo by <id>` の形式で入力してね'
+        });
+        return;
+      }
+      await this.replyTypos(message, userId as Snowflake, `<@${userId}>`);
+      return;
+    }
     await message.reply({
-      title: `† 今日の${senderName}のtypo †`,
+      title: 'Typoヘルプ',
+      description: `
+- 引数なし: あなたの今日のTypoを表示するよ
+- \`by <ユーザID>\`: そのIDの人の今日のTypoを表示するよ
+`
+    });
+    return;
+  }
+
+  private async replyTypos(
+    message: CommandMessage,
+    senderId: Snowflake,
+    senderName: string
+  ) {
+    const typos = await this.repo.allTyposByDate(senderId);
+    const description =
+      `***† 今日の${senderName}のtypo †***\n` +
+      typos.map((typo) => `- ${typo}`).join('\n');
+    await message.reply({
       description
     });
   }


### PR DESCRIPTION
**Issue:** #190

### Type of Change:

機能追加, 小さな仕様変更

### Details of implementation (実施内容)

`typo by <ユーザID>` で特定ユーザの今日の Typo リストも表示できるようにしました. それに伴い, 引数が多すぎる場合の専用ヘルプを追加しました.

ユーザ ID を用いて Embed メッセージ上でユーザ名解決のためにメンションしたのですが, これは `title` だと利用できませんでした. 元々のリスト表示を含リスト表示を全て `description` に統合しました.
