### PR TITLE
feat: 限界ポイントロールをかわえもんから自動で外すように

### DIFF
--- a/src/adaptor/discord-role.ts
+++ b/src/adaptor/discord-role.ts
@@ -13,4 +13,13 @@ export class DiscordRoleManager implements RoleManager {
     const member = await guild.members.fetch(targetMember);
     await member.roles.add(newRoleId);
   }
+
+  async removeRole(
+    targetMember: Snowflake,
+    removingRoleId: Snowflake
+  ): Promise<void> {
+    const guild = await this.client.guilds.fetch(this.guildId);
+    const member = await guild.members.fetch(targetMember);
+    await member.roles.remove(removingRoleId);
+  }
 }

--- a/src/adaptor/role-proxy.ts
+++ b/src/adaptor/role-proxy.ts
@@ -14,4 +14,7 @@ export const roleProxy = (
   runner: RoleResponseRunner<AllRoleModel>
 ) => {
   client.on('roleCreate', (role) => runner.triggerEvent('CREATE', map(role)));
+  client.on('roleUpdate', (_, role) =>
+    runner.triggerEvent('UPDATE', map(role))
+  );
 };

--- a/src/adaptor/role-proxy.ts
+++ b/src/adaptor/role-proxy.ts
@@ -6,7 +6,8 @@ import type { Snowflake } from '../model/id';
 type AllRoleModel = NewRole;
 
 const map: (role: Role) => AllRoleModel = (role) => ({
-  roleId: role.id as Snowflake
+  roleId: role.id as Snowflake,
+  name: role.name
 });
 
 export const roleProxy = (

--- a/src/runner/role.ts
+++ b/src/runner/role.ts
@@ -1,4 +1,4 @@
-export type RoleEvent = 'CREATE';
+export type RoleEvent = 'CREATE' | 'UPDATE';
 
 export interface RoleEventResponder<R> {
   on(event: RoleEvent, role: R): Promise<void>;

--- a/src/service/kawaemon-has-all-roles.ts
+++ b/src/service/kawaemon-has-all-roles.ts
@@ -4,6 +4,7 @@ import type { StandardOutput } from './output';
 
 export interface NewRole {
   roleId: Snowflake;
+  name: string;
 }
 
 export interface RoleManager {
@@ -19,13 +20,25 @@ export class KawaemonHasAllRoles implements RoleEventResponder<NewRole> {
   ) {}
 
   async on(event: RoleEvent, role: NewRole): Promise<void> {
-    if (event !== 'CREATE') {
-      return;
+    switch (event) {
+      case 'CREATE':
+        await this.manager.addRole(this.kawaemonId, role.roleId);
+        await this.output.sendEmbed({
+          title: '***Kawaemon has given a new role***',
+          description: `<@&${role.roleId}>をかわえもんにもつけといたよ。`
+        });
+        return;
+      case 'UPDATE':
+        // 限界ポイント1000超えなどはこの形式で始まる. 詳細: https://github.com/approvers/OreOreBot2/issues/155
+        if (!role.name.startsWith('限界ポイント')) {
+          return;
+        }
+        await this.manager.removeRole(this.kawaemonId, role.roleId);
+        await this.output.sendEmbed({
+          title: '***Kawaemon has dropped a new role***',
+          description: `<@&${role.roleId}>をかわえもんからはずしといたよ。`
+        });
+        return;
     }
-    await this.manager.addRole(this.kawaemonId, role.roleId);
-    await this.output.sendEmbed({
-      title: '***Kawaemon has given a new role***',
-      description: `<@&${role.roleId}>をかわえもんにもつけといたよ。`
-    });
   }
 }

--- a/src/service/kawaemon-has-all-roles.ts
+++ b/src/service/kawaemon-has-all-roles.ts
@@ -8,6 +8,7 @@ export interface NewRole {
 
 export interface RoleManager {
   addRole(targetMember: Snowflake, newRoleId: Snowflake): Promise<void>;
+  removeRole(targetMember: Snowflake, removingRoleId: Snowflake): Promise<void>;
 }
 
 export class KawaemonHasAllRoles implements RoleEventResponder<NewRole> {


### PR DESCRIPTION
**Issue:** #155

### Type of Change:

機能追加

### Details of implementation (実施内容)

ロールが `限界ポイント` で始まるロール名へ変更されたとき, そのロールをかわえもんから自動で外すようにしました.
