### PR TITLE
fix: Revert "feat: 限界ポイントロールをかわえもんから自動で外すように (#234)"

### DIFF
--- a/src/service/kawaemon-has-all-roles.test.ts
+++ b/src/service/kawaemon-has-all-roles.test.ts
@@ -36,31 +36,6 @@ describe('kawaemon has all roles', () => {
     });
   });
 
-  it('kawaemon drop a new role', async () => {
-    const updatedRoleId = '18475613045613281703151' as Snowflake;
-    const addRole = vi.spyOn(manager, 'addRole');
-    const removeRole = vi.spyOn(manager, 'removeRole');
-    const sendEmbed = vi.spyOn(output, 'sendEmbed');
-
-    await responder.on('UPDATE', {
-      roleId: updatedRoleId,
-      name: '限界ポイント8000超え'
-    });
-
-    expect(addRole).not.toHaveBeenCalled();
-    expect(removeRole).toHaveBeenCalledWith(KAWAEMON_ID, updatedRoleId);
-    expect(sendEmbed).toHaveBeenCalledWith({
-      title: '***Kawaemon has dropped a new role***',
-      description: `<@&18475613045613281703151>をかわえもんからはずしといたよ。`,
-      fields: [
-        {
-          name: '理由',
-          value: '限界ポイントと名のつくロールは自動で外すよ。'
-        }
-      ]
-    });
-  });
-
   it('must not drop a new role', async () => {
     const updatedRoleId = '18475613045613281703151' as Snowflake;
     const addRole = vi.spyOn(manager, 'addRole');

--- a/src/service/kawaemon-has-all-roles.ts
+++ b/src/service/kawaemon-has-all-roles.ts
@@ -28,35 +28,6 @@ export class KawaemonHasAllRoles implements RoleEventResponder<NewRole> {
           description: `<@&${role.roleId}>をかわえもんにもつけといたよ。`
         });
         return;
-      case 'UPDATE': {
-        const shouldBeDropped = this.shouldBeDropped(role.name);
-        if (!shouldBeDropped[0]) {
-          return;
-        }
-        const [, reason] = shouldBeDropped;
-        await this.manager.removeRole(this.kawaemonId, role.roleId);
-        await this.output.sendEmbed({
-          title: '***Kawaemon has dropped a new role***',
-          description: `<@&${role.roleId}>をかわえもんからはずしといたよ。`,
-          fields: [
-            {
-              name: '理由',
-              value: reason
-            }
-          ]
-        });
-        return;
-      }
     }
-  }
-
-  shouldBeDropped(
-    roleName: string
-  ): [should: true, reason: string] | [should: false] {
-    // 限界ポイント1000超えなどはこの形式で始まる. 詳細: https://github.com/approvers/OreOreBot2/issues/155
-    if (roleName.startsWith('限界ポイント')) {
-      return [true, '限界ポイントと名のつくロールは自動で外すよ。'];
-    }
-    return [false];
   }
 }


### PR DESCRIPTION
#234 で追加した機能が Discord の仕様によって期待通りに動作しなかったため, 差し戻します.
