### PR TITLE
feat: help コマンドをページめくりできるように

### DIFF
--- a/src/model/embed-message.ts
+++ b/src/model/embed-message.ts
@@ -22,3 +22,5 @@ export interface EmbedMessage {
   url?: string;
   thumbnail?: EmbedMessageThumbnail;
 }
+
+export type EmbedPage = Omit<EmbedMessage, 'footer'>;

--- a/src/service/command-message.ts
+++ b/src/service/command-message.ts
@@ -1,4 +1,4 @@
-import type { EmbedMessage } from '../model/embed-message.js';
+import type { EmbedMessage, EmbedPage } from '../model/embed-message.js';
 import type { MessageEventResponder } from '../runner/index.js';
 import type { Snowflake } from '../model/id.js';
 
@@ -61,10 +61,17 @@ export interface CommandMessage {
    * このメッセージに `message` の内容で返信する。
    *
    * @param message
-   * @type {readonly string[]}
    * @memberof CommandMessage
    */
   reply(message: EmbedMessage): Promise<SentMessage>;
+
+  /**
+   * このメッセージにページ送りできる `pages` で返信する。
+   *
+   * @param pages
+   * @memberof CommandMessage
+   */
+  replyPages(pages: EmbedPage[]): Promise<void>;
 
   /**
    * このメッセージに `emoji` の絵文字でリアクションする。
@@ -116,6 +123,7 @@ export const createMockMessage = (
         Promise.resolve({
           edit: () => Promise.resolve()
         }),
+  replyPages: () => Promise.resolve(),
   react: () => Promise.resolve(),
   ...partial
 });

--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -4,7 +4,7 @@ import type {
   HelpInfo
 } from './command-message.js';
 import type { MessageEvent, MessageResponseRunner } from '../runner/index.js';
-import type { EmbedMessageField } from '../model/embed-message.js';
+import type { EmbedPage } from '../model/embed-message.js';
 
 export class HelpCommand implements CommandResponder {
   help: Readonly<HelpInfo> = {
@@ -29,10 +29,8 @@ export class HelpCommand implements CommandResponder {
     const helps = this.runner
       .getResponders()
       .map((responder) => responder.help);
-    const fields: EmbedMessageField[] = helps.map((help) =>
-      this.buildField(help)
-    );
-    await message.reply({ fields });
+    const pages: EmbedPage[] = helps.map((help) => this.buildField(help));
+    await message.replyPages(pages);
   }
 
   private buildField({
@@ -40,7 +38,7 @@ export class HelpCommand implements CommandResponder {
     description,
     commandName,
     argsFormat
-  }: Readonly<HelpInfo>): { name: string; value: string } {
+  }: Readonly<HelpInfo>): EmbedPage {
     const patternsWithDesc: [string, string][] = argsFormat.map(
       ({ name, description, defaultValue }) => [
         defaultValue === undefined ? `<${name}>` : `[${name}=${defaultValue}]`,
@@ -52,8 +50,8 @@ export class HelpCommand implements CommandResponder {
       .join('\n');
     const patterns = patternsWithDesc.map(([pattern]) => pattern);
     return {
-      name: title,
-      value: `${description}
+      title,
+      description: `${description}
 \`${commandName.join('/')}${['', ...patterns].join(' ')}\`
 ${argsDecrptions}`
     };


### PR DESCRIPTION
**Issue:** #256

### Type of Change:

機能の新規追加

### Details of implementation (実施内容)

Message Components を利用して実装した戻る/進むボタンを用いて, Embed メッセージのページめくりを実装しました. また, `help` コマンドにおいてこれを利用するように書き換えました.
