### PR TITLE
chore: Dependabot version update - `GitHub Actions` を監視対象エコシステムに追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,11 @@ updates:
       interval: "daily"
     target-branch: main
     commit-message:
-      prefix: chore
+      prefix: chore(npm)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: chore(ci)
+    target-branch: main

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "m2en"
+      - "MikuroXina"
     target-branch: main
     commit-message:
       prefix: chore(npm)
@@ -11,6 +14,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "m2en"
+      - "MikuroXina"
+    target-branch: main
     commit-message:
       prefix: chore(ci)
-    target-branch: main


### PR DESCRIPTION
**Issue:** #

### Type of Change:

新規追加, 変更

### Details of implementation (実施内容)

Dependabot version updateにて、GitHub Actions を監視対象エコシステムに追加し、使用している "アクション" に更新がある場合は Dependabot がPRを作成します。

これにより、どのエコシステムのPRなのかがわかるようにCommit Prefixで示すようにしました。

- `chore(npm)`: npmパッケージのアップデート
- `chore(ci)`: アクション(GitHub Action)のアップデート

### Additional Information (追加情報)

今後作成される Dependabot version update のPRに @m2en , @MikuroXina をReviewersとしてDependabotが指定するようにしました。