### PR TITLE
feat: デバッグコマンドの追加

### DIFF
--- a/src/adaptor/discord/message-repo.ts
+++ b/src/adaptor/discord/message-repo.ts
@@ -1,0 +1,23 @@
+import type { Client } from 'discord.js';
+import type { MessageRepository } from '../../service/debug.js';
+import type { Snowflake } from '../../model/id.js';
+
+export class DiscordMessageRepository implements MessageRepository {
+  constructor(private readonly client: Client) {}
+
+  async getMessageContent(
+    channelId: Snowflake,
+    messageId: Snowflake
+  ): Promise<string | undefined> {
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel || !channel.isText()) {
+      throw new Error(`text channel (${channelId}) not found`);
+    }
+    try {
+      const message = await channel.messages.fetch(messageId);
+      return message.content || '';
+    } catch (e) {
+      return undefined;
+    }
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -40,6 +40,7 @@ import {
 } from '../service/index.js';
 import type { AssetKey } from '../service/party.js';
 import { DiscordMemberStats } from '../adaptor/discord/member-stats.js';
+import { DiscordMessageRepository } from '../adaptor/discord/message-repo.js';
 import { DiscordRoleManager } from '../adaptor/discord/role.js';
 import { DiscordSheriff } from '../adaptor/discord/sheriff.js';
 import { DiscordWS } from '../adaptor/discord/ws.js';
@@ -130,7 +131,8 @@ registerAllCommandResponder({
   stats: new DiscordMemberStats(client, GUILD_ID as Snowflake),
   sheriff: new DiscordSheriff(client),
   ping: new DiscordWS(client),
-  fetcher: new GenVersionFetcher()
+  fetcher: new GenVersionFetcher(),
+  messageRepo: new DiscordMessageRepository(client)
 });
 
 const provider = new VoiceRoomProxy<VoiceChannelParticipant>(

--- a/src/service/debug.test.ts
+++ b/src/service/debug.test.ts
@@ -1,6 +1,6 @@
 import { DebugCommand, MessageRepository } from './debug.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Snowflake } from '../model/id.js';
+import type { Snowflake } from '../model/id.js';
 import { createMockMessage } from './command-message.js';
 
 describe('debug', () => {

--- a/src/service/debug.test.ts
+++ b/src/service/debug.test.ts
@@ -1,0 +1,82 @@
+import { DebugCommand, MessageRepository } from './debug.js';
+import { describe, expect, it, vi } from 'vitest';
+import { Snowflake } from '../model/id.js';
+import { createMockMessage } from './command-message.js';
+
+describe('debug', () => {
+  const repo: MessageRepository = {
+    getMessageContent: () => Promise.resolve(undefined)
+  };
+  const responder = new DebugCommand(repo);
+
+  it('outputs debug format', async () => {
+    const getMessageContent = vi
+      .spyOn(repo, 'getMessageContent')
+      .mockImplementation(() => Promise.resolve('🅰️ Hoge'));
+    const reply = vi.fn(() => Promise.resolve());
+    await responder.on(
+      'CREATE',
+      createMockMessage(
+        {
+          args: ['debug', '1423523'],
+          senderChannelId: '8623233' as Snowflake
+        },
+        reply
+      )
+    );
+    expect(getMessageContent).toHaveBeenCalledWith('8623233', '1423523');
+    expect(reply).toHaveBeenCalledWith({
+      title: 'デバッグ出力',
+      description: '```\n🅰️ Hoge\n```'
+    });
+  });
+
+  it('replaces triple back quotes', async () => {
+    const getMessageContent = vi
+      .spyOn(repo, 'getMessageContent')
+      .mockImplementation(() =>
+        Promise.resolve(`\`\`\`js
+console.log(\`Hello, \${name}!\`);
+\`\`\``)
+      );
+    const reply = vi.fn(() => Promise.resolve());
+    await responder.on(
+      'CREATE',
+      createMockMessage(
+        {
+          args: ['debug', '1423523'],
+          senderChannelId: '8623233' as Snowflake
+        },
+        reply
+      )
+    );
+    expect(getMessageContent).toHaveBeenCalledWith('8623233', '1423523');
+    expect(reply).toHaveBeenCalledWith({
+      title: 'デバッグ出力',
+      description: `\`\`\`
+'''js
+console.log(\`Hello, \${name}!\`);
+'''
+\`\`\``,
+      footer:
+        "三連続の ` (バッククォート) は ' (シングルクォート) に置換してあるよ。"
+    });
+  });
+
+  it('does not react on deletion', async () => {
+    const getMessageContent = vi.spyOn(repo, 'getMessageContent');
+    const reply = vi.fn(() => Promise.resolve());
+    await responder.on(
+      'DELETE',
+      createMockMessage(
+        {
+          args: ['debug', '1423523'],
+          senderChannelId: '8623233' as Snowflake
+        },
+        reply
+      )
+    );
+    expect(getMessageContent).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+  });
+});

--- a/src/service/debug.test.ts
+++ b/src/service/debug.test.ts
@@ -1,9 +1,13 @@
 import { DebugCommand, MessageRepository } from './debug.js';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Snowflake } from '../model/id.js';
 import { createMockMessage } from './command-message.js';
 
 describe('debug', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
   const repo: MessageRepository = {
     getMessageContent: () => Promise.resolve(undefined)
   };
@@ -60,6 +64,26 @@ console.log(\`Hello, \${name}!\`);
 \`\`\``,
       footer:
         "三連続の ` (バッククォート) は ' (シングルクォート) に置換してあるよ。"
+    });
+  });
+
+  it('errors on message not found', async () => {
+    const getMessageContent = vi.spyOn(repo, 'getMessageContent');
+    const reply = vi.fn(() => Promise.resolve());
+    await responder.on(
+      'CREATE',
+      createMockMessage(
+        {
+          args: ['debug', '1423523'],
+          senderChannelId: '8623233' as Snowflake
+        },
+        reply
+      )
+    );
+    expect(getMessageContent).toHaveBeenCalledWith('8623233', '1423523');
+    expect(reply).toHaveBeenCalledWith({
+      title: '指定のメッセージが見つからなかったよ',
+      description: 'そのメッセージがこのチャンネルにあるかどうか確認してね。'
     });
   });
 

--- a/src/service/debug.ts
+++ b/src/service/debug.ts
@@ -1,0 +1,61 @@
+import type {
+  CommandMessage,
+  CommandResponder,
+  HelpInfo
+} from './command-message.js';
+import type { MessageEvent } from '../runner/message.js';
+import type { Snowflake } from '../model/id.js';
+
+export interface MessageRepository {
+  getMessageContent(
+    channelId: Snowflake,
+    messageId: Snowflake
+  ): Promise<string | undefined>;
+}
+
+export class DebugCommand implements CommandResponder {
+  help: Readonly<HelpInfo> = {
+    title: 'デバッガーはらちょ',
+    description:
+      'メッセージIDを渡すと、同じチャンネル内にあればそれをコードブロックとして表示するよ',
+    commandName: ['debug'],
+    argsFormat: [
+      {
+        name: 'messageId',
+        description: 'デバッグ表示したいメッセージのID'
+      }
+    ]
+  };
+
+  constructor(private readonly repo: MessageRepository) {}
+
+  async on(event: MessageEvent, message: CommandMessage): Promise<void> {
+    if (event !== 'CREATE') {
+      return;
+    }
+
+    const [commandName, messageId] = message.args;
+    if (!this.help.commandName.includes(commandName)) {
+      return;
+    }
+    const content = await this.repo.getMessageContent(
+      message.senderChannelId,
+      messageId as Snowflake
+    );
+    if (!content) {
+      await message.reply({
+        title: '指定のメッセージが見つからなかったよ',
+        description: 'そのメッセージがこのチャンネルにあるかどうか確認してね。'
+      });
+      return;
+    }
+    const contentIncludesBackQuotes = content.includes('`');
+    await message.reply({
+      title: 'デバッグ出力',
+      description: `\`\`\`\n${content.replace(/`/g, "'")}\n\`\`\``,
+      footer: contentIncludesBackQuotes
+        ? "` (バッククォート) は ' (シングルクォート) に置換してあるよ。"
+        : undefined
+    });
+  }
+}

--- a/src/service/debug.ts
+++ b/src/service/debug.ts
@@ -49,12 +49,12 @@ export class DebugCommand implements CommandResponder {
       });
       return;
     }
-    const contentIncludesBackQuotes = content.includes('`');
+    const contentIncludesBackQuotes = content.includes('```');
     await message.reply({
       title: 'デバッグ出力',
-      description: `\`\`\`\n${content.replace(/`/g, "'")}\n\`\`\``,
+      description: `\`\`\`\n${content.replace(/```/g, "'''")}\n\`\`\``,
       footer: contentIncludesBackQuotes
-        ? "` (バッククォート) は ' (シングルクォート) に置換してあるよ。"
+        ? "三連続の ` (バッククォート) は ' (シングルクォート) に置換してあるよ。"
         : undefined
     });
   }

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -17,6 +17,7 @@ import {
   composeRoleEventResponders
 } from '../runner/index.js';
 import type { CommandMessage, CommandResponder } from './command-message.js';
+import { DebugCommand, MessageRepository } from './debug.js';
 import {
   type DeletionObservable,
   DeletionRepeater
@@ -76,7 +77,8 @@ export const registerAllCommandResponder = ({
   stats,
   sheriff,
   ping,
-  fetcher
+  fetcher,
+  messageRepo
 }: {
   typoRepo: TypoRepository;
   reservationRepo: ReservationRepository;
@@ -90,6 +92,7 @@ export const registerAllCommandResponder = ({
   sheriff: Sheriff;
   ping: Ping;
   fetcher: VersionFetcher;
+  messageRepo: MessageRepository;
 }) => {
   const allResponders = [
     new TypoReporter(typoRepo, clock, scheduleRunner),
@@ -107,7 +110,8 @@ export const registerAllCommandResponder = ({
     new KokuseiChousa(stats),
     new SheriffCommand(sheriff),
     new PingCommand(ping),
-    new GetVersionCommand(fetcher)
+    new GetVersionCommand(fetcher),
+    new DebugCommand(messageRepo)
   ];
   for (const responder of allResponders) {
     commandRunner.addResponder(responder);


### PR DESCRIPTION
**Issue:** #312

### Type of Change:

機能の新規追加

### Details of implementation (実施内容)

メッセージの内容をデバッグ出力するためのコマンドとして, `!debug <メッセージ ID>` という形式のコマンドを追加しました. これは指定した ID のメッセージをコードブロックにして表示し, 三連続バッククォート (` ``` `) は三連続シングルクォート (`'''`) に置き換えます. この実行には, その ID のメッセージがコマンドを発行したチャンネルに存在している必要があり, さもなくばエラーメッセージを返信します.
