### PR TITLE
docs: issue close keywordを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom-issue.md
+++ b/.github/ISSUE_TEMPLATE/custom-issue.md
@@ -1,6 +1,6 @@
 ---
 name: Custom-Issue
-about: 完全カスタマイズのIssueを作成します。
+about: バグ報告、機能要望に該当しないIssueを作成します。
 title: ''
 labels: ''
 assignees: ''

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,13 @@
-**Issue:** #
+close #
+
+<!--
+    このプルリクエストに関連し、マージ時に自動的にクローズしたいIssueの番号を記載します。
+    複数のIssueを記載する場合は、改行で区切ってください。
+    例:
+    close #1
+    close #2
+    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+-->
 
 ### Type of Change:
 


### PR DESCRIPTION
### Type of Change:

ドキュメント(テンプレート)の改善

### Details of implementation (実施内容)

プルリクエストのコンテキストに追加すると指定のIssue番号のIssueを自動でクローズする **"issue close keywords"** を追加しました。

参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

`.github/ISSUE_TEMPLATE/custom-issue.md` について、説明欄( `about` )が不適切だったため、その修正も加えています。