### PR TITLE
chore: Husky ファイルのマイグレーション

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "discord.js": "^13.8.1",
     "dotenv": "^16.0.1",
     "ffmpeg-static": "^5.0.2",
-    "husky": "^8.0.1",
     "nanoid": "^4.0.0",
     "tweetnacl": "^1.0.3",
     "yaml": "^2.1.1"
@@ -57,6 +56,7 @@
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-markdown": "^2.2.1",
+    "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "make-dir-cli": "^3.0.0",
     "prettier": "^2.7.1",


### PR DESCRIPTION
### Type of Change:

コミットフックの修正, 依存関係の更新

### Cause of the Problem (問題の原因)

[husky](https://typicode.github.io/husky/#/) のバージョンを自動更新した際に, WSL などの一部環境で pre-commit が動作しなくなっていました.

### Details of implementation (実施内容)

`npx husky-init` にを実行し, `.husky/pre-commit` を再生成して `husky` を `devDependencies` へと移動させました.

### Additional Information (追加情報)

依存関係に対して dependabot が破壊的なバージョン更新を行う際に, そのままマージしてよいのかどうか検証するプロセスを検討すべきかもしれない.
