### PR TITLE
feat: 逃げたねコピペ構文の追加

### DIFF
--- a/src/service/meme.ts
+++ b/src/service/meme.ts
@@ -9,10 +9,11 @@ import { dousurya } from './meme/dousurya.js';
 import { hukueki } from './meme/hukueki.js';
 import { lolicon } from './meme/lolicon.js';
 import { n } from './meme/n.js';
+import { nigetane } from './meme/nigetane.js';
 import parse from 'cli-argparse';
 import { takopi } from './meme/takopi.js';
 
-const memes = [dousurya, hukueki, lolicon, n, takopi];
+const memes = [dousurya, hukueki, lolicon, n, takopi, nigetane];
 const memesByCommandName: Record<
   string,
   MemeTemplate<string, string> | undefined

--- a/src/service/meme/nigetane.ts
+++ b/src/service/meme/nigetane.ts
@@ -1,7 +1,7 @@
 import type { MemeTemplate } from '../../model/meme-template.js';
 
 const template = (inject: string) =>
-  `--今、逃げたね。 逃げたでしょ。\n${inject}から悪くないって、正当化した。\n自分がいい子だって言い訳が見つかってよかったね。\nどんな気分？\n\n……手遅れなのは頭（おつむ）からなのかな。\nだって、 いつまでもそのまんまだよ。\n今だって、ずーっとそう。\n\n――ほんとあなたって、自分さえ良ければ良いんだね。`;
+  `――今、逃げたね。\n逃げたでしょ。\n${inject}から悪くないって、正当化した。\n\n自分がいい子だって言い訳が見つかってよかったね。\nどんな気分？\n\n……手遅れなのは頭（おつむ）からなのかな。\n\nだって、\nいつまでもそのまんまだよ。\n今だって、ずーっとそう。\n\n――ほんとあなたって、自分さえ良ければ良いんだね。`;
 
 export const nigetane: MemeTemplate<never, never> = {
   commandNames: ['nigetane'],

--- a/src/service/meme/nigetane.ts
+++ b/src/service/meme/nigetane.ts
@@ -5,7 +5,7 @@ const template = (inject: string) =>
 
 export const nigetane: MemeTemplate<never, never> = {
   commandNames: ['nigetane'],
-  description: 'Arcaeaの光が自身を断罪したセリフ, 通称逃げたねコピペ.',
+  description: '… 〜から悪くないって、… (from Arcaea "Final Verdict")',
   flagsKeys: [],
   optionsKeys: [],
   errorMessage: '……手遅れなのは頭（おつむ）からなのかな。',

--- a/src/service/meme/nigetane.ts
+++ b/src/service/meme/nigetane.ts
@@ -1,0 +1,13 @@
+import type { MemeTemplate } from '../../model/meme-template.js';
+
+const template = (inject: string) =>
+  `--今、逃げたね。 逃げたでしょ。\n${inject}から悪くないって、正当化した。\n自分がいい子だって言い訳が見つかってよかったね。\nどんな気分？\n\n……手遅れなのは頭（おつむ）からなのかな。\nだって、 いつまでもそのまんまだよ。\n今だって、ずーっとそう。\n\n――ほんとあなたって、自分さえ良ければ良いんだね。`;
+
+export const nigetane: MemeTemplate<never, never> = {
+  commandNames: ['nigetane'],
+  description: 'Arcaeaの光が自身を断罪したセリフ, 通称逃げたねコピペ.',
+  flagsKeys: [],
+  optionsKeys: [],
+  errorMessage: '……手遅れなのは頭（おつむ）からなのかな。',
+  generate: ({ body }) => template(body)
+};


### PR DESCRIPTION
### Type of Change:

逃げたねコピペ構文の追加.

### Details of implementation (実施内容)

他のmemeの実装に従い, 逃げたねコピペ構文を生成する機能を追加しました.

### Additional Information (追加情報)

見た目が思ってたのと違うかも知れません. あとArcaea勢への若干のネタバレの心配があります. 時事ネタなので.