### PR TITLE
feat: ロール数ランキングの追加

### DIFF
--- a/src/adaptor/discord/member-stats.ts
+++ b/src/adaptor/discord/member-stats.ts
@@ -1,8 +1,14 @@
+import type {
+  MemberWithRole,
+  MembersWithRoleRepository
+} from '../../service/role-rank.js';
 import type { Client } from 'discord.js';
 import type { MemberStats } from '../../service/kokusei-chousa.js';
 import type { Snowflake } from '../../model/id.js';
 
-export class DiscordMemberStats implements MemberStats {
+export class DiscordMemberStats
+  implements MemberStats, MembersWithRoleRepository
+{
   constructor(
     private readonly client: Client,
     private readonly guildId: Snowflake
@@ -23,5 +29,17 @@ export class DiscordMemberStats implements MemberStats {
     }
     const guildMemberList = await guild.members.list({ limit: 1000 });
     return guildMemberList.filter((member) => member.user.bot).size;
+  }
+
+  async fetchMembersWithRole(): Promise<MemberWithRole[]> {
+    const guild = await this.client.guilds.fetch(this.guildId);
+    if (!guild) {
+      throw new Error('guild not found');
+    }
+    const guildMemberList = await guild.members.list({ limit: 1000 });
+    return guildMemberList.map(({ displayName, roles }) => ({
+      displayName,
+      roles: roles.cache.size
+    }));
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -112,6 +112,7 @@ const commandRunner: MessageResponseRunner<CommandMessage, CommandResponder> =
   new MessageResponseRunner(
     new MessageProxy(client, transformerForCommand('!'))
   );
+const stats = new DiscordMemberStats(client, GUILD_ID as Snowflake);
 registerAllCommandResponder({
   typoRepo,
   reservationRepo,
@@ -127,11 +128,12 @@ registerAllCommandResponder({
   random: new MathRandomGenerator(),
   roomController: new DiscordVoiceRoomController(client),
   commandRunner,
-  stats: new DiscordMemberStats(client, GUILD_ID as Snowflake),
+  stats,
   sheriff: new DiscordSheriff(client),
   ping: new DiscordWS(client),
   fetcher: new GenVersionFetcher(),
-  messageRepo: new DiscordMessageRepository(client)
+  messageRepo: new DiscordMessageRepository(client),
+  membersRepo: stats
 });
 
 const provider = new VoiceRoomProxy<VoiceChannelParticipant>(

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -33,6 +33,7 @@ import {
 } from './kaere.js';
 import { KawaemonHasAllRoles, RoleManager } from './kawaemon-has-all-roles.js';
 import { KokuseiChousa, MemberStats } from './kokusei-chousa.js';
+import { MembersWithRoleRepository, RoleRank } from './role-rank.js';
 import { Ping, PingCommand } from './ping.js';
 import { Sheriff, SheriffCommand } from './stfu.js';
 import {
@@ -78,7 +79,8 @@ export const registerAllCommandResponder = ({
   sheriff,
   ping,
   fetcher,
-  messageRepo
+  messageRepo,
+  membersRepo
 }: {
   typoRepo: TypoRepository;
   reservationRepo: ReservationRepository;
@@ -93,6 +95,7 @@ export const registerAllCommandResponder = ({
   ping: Ping;
   fetcher: VersionFetcher;
   messageRepo: MessageRepository;
+  membersRepo: MembersWithRoleRepository;
 }) => {
   const allResponders = [
     new TypoReporter(typoRepo, clock, scheduleRunner),
@@ -111,7 +114,8 @@ export const registerAllCommandResponder = ({
     new SheriffCommand(sheriff),
     new PingCommand(ping),
     new GetVersionCommand(fetcher),
-    new DebugCommand(messageRepo)
+    new DebugCommand(messageRepo),
+    new RoleRank(membersRepo)
   ];
   for (const responder of allResponders) {
     commandRunner.addResponder(responder);

--- a/src/service/role-rank.test.ts
+++ b/src/service/role-rank.test.ts
@@ -1,0 +1,106 @@
+import { MembersWithRoleRepository, RoleRank } from './role-rank.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockMessage } from './command-message.js';
+
+describe('RoleRank', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const repo: MembersWithRoleRepository = {
+    fetchMembersWithRole: () =>
+      Promise.resolve([
+        {
+          defaultName: 'Baba',
+          nickName: 'Baba Is Baba',
+          roles: 8
+        },
+        {
+          defaultName: 'Keke',
+          nickName: undefined,
+          roles: 5
+        },
+        {
+          defaultName: 'Me',
+          nickName: 'Meme',
+          roles: 12
+        },
+        {
+          defaultName: 'Fofo',
+          nickName: 'Morizo',
+          roles: 2
+        },
+        {
+          defaultName: 'Jiji',
+          nickName: 'Alpaca',
+          roles: 3
+        },
+        {
+          defaultName: 'Wugan',
+          nickName: 'Bird',
+          roles: 4
+        }
+      ])
+  };
+  const roleRank = new RoleRank(repo);
+
+  it('ranks members', async () => {
+    const fetchMembersWithRole = vi.spyOn(repo, 'fetchMembersWithRole');
+    const fn = vi.fn();
+
+    await roleRank.on(
+      'CREATE',
+      createMockMessage(
+        {
+          args: ['rolerank']
+        },
+        fn
+      )
+    );
+
+    expect(fn).toHaveBeenCalledWith({
+      title: 'ロール数ランキング',
+      fields: [
+        {
+          name: '1 位',
+          value: 'Meme : 12 個'
+        },
+        {
+          name: '2 位',
+          value: 'Baba Is Baba : 8 個'
+        },
+        {
+          name: '3 位',
+          value: 'Keke : 5 個'
+        },
+        {
+          name: '4 位',
+          value: 'Bird : 4 個'
+        },
+        {
+          name: '5 位',
+          value: 'Alpaca : 3 個'
+        }
+      ]
+    });
+    expect(fetchMembersWithRole).toHaveBeenCalledOnce();
+  });
+
+  it('does not react on deletion', async () => {
+    const fetchMembersWithRole = vi.spyOn(repo, 'fetchMembersWithRole');
+    const fn = vi.fn();
+
+    await roleRank.on(
+      'DELETE',
+      createMockMessage(
+        {
+          args: ['rolerank']
+        },
+        fn
+      )
+    );
+
+    expect(fn).not.toBeCalled();
+    expect(fetchMembersWithRole).not.toHaveBeenCalled();
+  });
+});

--- a/src/service/role-rank.test.ts
+++ b/src/service/role-rank.test.ts
@@ -11,33 +11,27 @@ describe('RoleRank', () => {
     fetchMembersWithRole: () =>
       Promise.resolve([
         {
-          defaultName: 'Baba',
-          nickName: 'Baba Is Baba',
+          displayName: 'Baba Is Baba',
           roles: 8
         },
         {
-          defaultName: 'Keke',
-          nickName: undefined,
+          displayName: 'Keke',
           roles: 5
         },
         {
-          defaultName: 'Me',
-          nickName: 'Meme',
+          displayName: 'Meme',
           roles: 12
         },
         {
-          defaultName: 'Fofo',
-          nickName: 'Morizo',
+          displayName: 'Morizo',
           roles: 2
         },
         {
-          defaultName: 'Jiji',
-          nickName: 'Alpaca',
+          displayName: 'Alpaca',
           roles: 3
         },
         {
-          defaultName: 'Wugan',
-          nickName: 'Bird',
+          displayName: 'Bird',
           roles: 4
         }
       ])

--- a/src/service/role-rank.ts
+++ b/src/service/role-rank.ts
@@ -34,7 +34,7 @@ export class RoleRank implements CommandResponder {
     }
     const members = await this.repo.fetchMembersWithRole();
     members.sort((a, b) => b.roles - a.roles);
-    members.splice(10);
+    members.splice(5);
     const fields = members.map(({ defaultName, nickName, roles }, index) => ({
       name: `${index + 1} 位`,
       value: `${nickName ?? defaultName} : ${roles} 個`

--- a/src/service/role-rank.ts
+++ b/src/service/role-rank.ts
@@ -1,0 +1,48 @@
+import type {
+  CommandMessage,
+  CommandResponder,
+  HelpInfo
+} from './command-message.js';
+import { MessageEvent } from '../runner/message.js';
+
+export interface MemberWithRole {
+  defaultName: string;
+  nickName: string | undefined;
+  roles: number;
+}
+
+export interface MembersWithRoleRepository {
+  fetchMembersWithRole(): Promise<MemberWithRole[]>;
+}
+
+export class RoleRank implements CommandResponder {
+  help: Readonly<HelpInfo> = {
+    title: 'ロール数ランキング',
+    commandName: ['rolerank'],
+    argsFormat: [],
+    description: '各メンバーごとのロール数をランキング形式で表示するよ'
+  };
+
+  constructor(private readonly repo: MembersWithRoleRepository) {}
+
+  async on(event: MessageEvent, message: CommandMessage): Promise<void> {
+    if (event !== 'CREATE') {
+      return;
+    }
+    if (!this.help.commandName.includes(message.args[0])) {
+      return;
+    }
+    const members = await this.repo.fetchMembersWithRole();
+    members.sort((a, b) => b.roles - a.roles);
+    members.splice(10);
+    const fields = members.map(({ defaultName, nickName, roles }, index) => ({
+      name: `${index + 1} 位`,
+      value: `${nickName ?? defaultName} : ${roles} 個`
+    }));
+
+    await message.reply({
+      title: this.help.title,
+      fields
+    });
+  }
+}

--- a/src/service/role-rank.ts
+++ b/src/service/role-rank.ts
@@ -6,8 +6,7 @@ import type {
 import { MessageEvent } from '../runner/message.js';
 
 export interface MemberWithRole {
-  defaultName: string;
-  nickName: string | undefined;
+  displayName: string;
   roles: number;
 }
 
@@ -35,9 +34,9 @@ export class RoleRank implements CommandResponder {
     const members = await this.repo.fetchMembersWithRole();
     members.sort((a, b) => b.roles - a.roles);
     members.splice(5);
-    const fields = members.map(({ defaultName, nickName, roles }, index) => ({
+    const fields = members.map(({ displayName, roles }, index) => ({
       name: `${index + 1} 位`,
-      value: `${nickName ?? defaultName} : ${roles} 個`
+      value: `${displayName} : ${roles} 個`
     }));
 
     await message.reply({


### PR DESCRIPTION
close #338.

### Type of Change:

機能の新規追加

### Details of implementation (実施内容)

`!rolerank` でロール数のランキングを表示する機能を追加しました. 各メンバーごとのロール数でソートし, 上位 5 名をランキング形式で表示します. ロール数が同じだった場合の処理, 表示する個数を指定できる機能などは実施していませんので, 必要であればお申し付けください.
