### PR TITLE
feat: PREFIX 環境変数でボットの接頭辞を変えられるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ yarn start
 | `DISCORD_TOKEN`   | BOT のトークン                                                  |
 | `MAIN_CHANNEL_ID` | VoiceDiff(VC 入退室ログ)を送信する **テキスト** チャンネルの ID |
 | `GUILD_ID`        | 限界開発鯖の ID                                                 |
+| `PREFIX`          | コマンドの接頭辞、デフォルト値は `"!"`                          |

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -61,7 +61,7 @@ const {
   MAIN_CHANNEL_ID: mainChannelId,
   GUILD_ID,
   PREFIX
-} = extractEnv(['DISCORD_TOKEN', 'MAIN_CHANNEL_ID', 'GUILD_ID'], {
+} = extractEnv(['DISCORD_TOKEN', 'MAIN_CHANNEL_ID', 'GUILD_ID', 'PREFIX'], {
   PREFIX: '!'
 });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -59,8 +59,11 @@ dotenv.config();
 const {
   DISCORD_TOKEN: token,
   MAIN_CHANNEL_ID: mainChannelId,
-  GUILD_ID
-} = extractEnv(['DISCORD_TOKEN', 'MAIN_CHANNEL_ID', 'GUILD_ID']);
+  GUILD_ID,
+  PREFIX
+} = extractEnv(['DISCORD_TOKEN', 'MAIN_CHANNEL_ID', 'GUILD_ID'], {
+  PREFIX: '!'
+});
 
 const intents = [
   GatewayIntentBits.Guilds, // GUILD_CREATE による初期化
@@ -110,7 +113,7 @@ const scheduleRunner = new ScheduleRunner(clock);
 
 const commandRunner: MessageResponseRunner<CommandMessage, CommandResponder> =
   new MessageResponseRunner(
-    new MessageProxy(client, transformerForCommand('!'))
+    new MessageProxy(client, transformerForCommand(PREFIX))
   );
 const stats = new DiscordMemberStats(client, GUILD_ID as Snowflake);
 registerAllCommandResponder({


### PR DESCRIPTION
### Type of Change:

機能の新規追加, 環境変数の新規追加

### Details of implementation (実施内容)

`PREFIX` 環境変数によりコマンドの接頭辞をカスタマイズできる機能を追加しました.

### Additional Information (追加情報)

テスト用に起動したボットの `PREFIX` を変えておくことで, 本来のボットを動かしつつテスト用のボットアカウントを実行してもコマンドが衝突しなくなります. それ以外の機能 (メッセージ削除への反応など) はまだ重複するので, そういった非コマンド機能を無効化できるようにする変更も予定しています.
