### PR TITLE
fix: 空のメッセージに反応するバグを修正

### DIFF
--- a/src/adaptor/proxy/transformer/message-convert.ts
+++ b/src/adaptor/proxy/transformer/message-convert.ts
@@ -58,6 +58,9 @@ export const observableTransformer: Transformer<
   RawMessage
 > = (handler) => async (raw: RawMessage) => {
   await fetchMessage(raw);
+  if (raw.content === null || raw.content === '') {
+    return;
+  }
   return handler(observableMessage(raw));
 };
 


### PR DESCRIPTION
### Type of Change:

コードのバグ修正

### Details of implementation (実施内容)

Discord.js のバージョン更新の際に, メッセージ本文が `null` の代わりに `''` になることがある仕様変更を確認していました. しかし, それに起因するバグが発生したため検知して弾くようにコードを修正しました.
