### PR TITLE
feat: stfu で削除個数を指定できるように

### DIFF
--- a/src/adaptor/discord/sheriff.ts
+++ b/src/adaptor/discord/sheriff.ts
@@ -6,13 +6,14 @@ export class DiscordSheriff implements Sheriff {
   private queue: (() => void)[] = [];
 
   constructor(private readonly client: Client) {
+    const INTERVAL_MS = 1000;
     setInterval(() => {
       const first = this.queue.shift();
       if (!first) {
         return;
       }
       first();
-    }, 500);
+    }, INTERVAL_MS);
   }
 
   executeMessage(channelId: Snowflake, historyRange: number): Promise<void> {
@@ -34,10 +35,13 @@ export class DiscordSheriff implements Sheriff {
     if (channel.type !== ChannelType.GuildText)
       throw new Error('this channel is not text channel.');
 
-    const messages = await channel.messages.fetch({ limit: historyRange });
+    const messages = await channel.messages.fetch({
+      limit: historyRange,
+      cache: false
+    });
 
     const targetMessage = messages.find(
-      (message) => message.author.id === harachoId
+      (message) => message.author.id === harachoId && message.deletable
     );
     if (!targetMessage) return;
     await targetMessage.delete();

--- a/src/service/command/stfu.test.ts
+++ b/src/service/command/stfu.test.ts
@@ -32,6 +32,49 @@ describe('stfu', () => {
     expect(react).toHaveBeenCalledWith('👌');
   });
 
+  it('executes specified times', async () => {
+    const executeMessage = vi.spyOn(sheriff, 'executeMessage');
+    const fn = vi.fn();
+    const react = vi.fn<[string]>(() => Promise.resolve());
+    await responder.on(
+      'CREATE',
+      createMockMessage({
+        args: ['stfu', '25'],
+        reply: fn,
+        react
+      })
+    );
+
+    expect(fn).not.toHaveBeenCalled();
+    expect(executeMessage).nthCalledWith(
+      25,
+      '711127633810817026' as Snowflake,
+      50
+    );
+    expect(react).toHaveBeenCalledWith('👌');
+  });
+
+  it('errors invalid specification', async () => {
+    const executeMessage = vi.spyOn(sheriff, 'executeMessage');
+    const fn = vi.fn();
+    const react = vi.fn<[string]>(() => Promise.resolve());
+    await responder.on(
+      'CREATE',
+      createMockMessage({
+        args: ['stfu', '51'],
+        reply: fn,
+        react
+      })
+    );
+
+    expect(fn).toHaveBeenCalledWith({
+      title: '引数の範囲エラー',
+      description: '1 以上 50 以下の整数を指定してね。'
+    });
+    expect(executeMessage).not.toHaveBeenCalled();
+    expect(react).not.toHaveBeenCalled();
+  });
+
   it('delete message', async () => {
     const executeMessage = vi.spyOn(sheriff, 'executeMessage');
     const fn = vi.fn();

--- a/src/service/command/stfu.ts
+++ b/src/service/command/stfu.ts
@@ -31,9 +31,17 @@ export interface Sheriff {
 export class SheriffCommand implements CommandResponder {
   help: Readonly<HelpInfo> = {
     title: '治安統率機構',
-    description: 'はらちょの治安維持コマンドだよ',
+    description:
+      'はらちょがうるさいときに治安維持するためのコマンドだよ。最新メッセージから 50 件以内のはらちょのメッセージを指定の個数だけ削除するよ。',
     commandName: ['stfu'],
-    argsFormat: []
+    argsFormat: [
+      {
+        name: 'numbersToRemove',
+        description:
+          'はらちょのメッセージを削除する個数だよ。1 以上 50 以下の整数で指定してね。',
+        defaultValue: '1'
+      }
+    ]
   };
 
   constructor(private readonly sheriff: Sheriff) {}
@@ -43,13 +51,22 @@ export class SheriffCommand implements CommandResponder {
       return;
     }
 
-    const [commandName] = message.args;
+    const [commandName, numbersToRemove = '1'] = message.args;
     if (!this.help.commandName.includes(commandName)) {
       return;
     }
-
-    const channel = message.senderChannelId;
-    await this.sheriff.executeMessage(channel, 50);
+    const toRemove = parseInt(numbersToRemove, 10);
+    if (Number.isNaN(toRemove) || !(1 <= toRemove && toRemove <= 50)) {
+      await message.reply({
+        title: '引数の範囲エラー',
+        description: '1 以上 50 以下の整数を指定してね。'
+      });
+      return;
+    }
+    for (let i = 0; i < toRemove; ++i) {
+      const channel = message.senderChannelId;
+      await this.sheriff.executeMessage(channel, 50);
+    }
     await message.react('👌');
   }
 }


### PR DESCRIPTION
Closes #347.

### Type of Change:

機能の新規追加

### Details of implementation (実施内容)

`!stfu 25`
のように削除個数を指定できるようになりました. 指定した回数分繰り返して実行したのと同じ扱いになります.

#347 で提案されていた探索範囲を指定できるようにする機能は, 大きくしすぎると予期しない古いメッセージの削除を招き, 小さくしすぎると全く削除できません. 少し使いづらいと判断して実装しませんでしたが, うまい活用方法やコマンド体系, 機能などがあればお申し付けください.

