### PR TITLE
feat: 燃えたmemeの追加

### DIFF
--- a/src/service/command/meme.test.ts
+++ b/src/service/command/meme.test.ts
@@ -146,6 +146,24 @@ describe('meme', () => {
     );
   });
 
+  it('use case of moeta', async () => {
+    await responder.on(
+      'CREATE',
+      createMockMessage(
+        {
+          args: ['moeta', '雪']
+        },
+        (message) => {
+          expect(message).toStrictEqual({
+            description:
+              '「久留米の花火大会ね、寮から見れたの?」\n「うん ついでに雪が燃えた」\n「は?」'
+          });
+          return Promise.resolve();
+        }
+      )
+    );
+  });
+
   it('args space', async () => {
     await responder.on(
       'CREATE',

--- a/src/service/command/meme.test.ts
+++ b/src/service/command/meme.test.ts
@@ -274,6 +274,25 @@ describe('meme', () => {
     );
   });
 
+  it('args null (moeta)', async () => {
+    await responder.on(
+      'CREATE',
+      createMockMessage(
+        {
+          args: ['moeta']
+        },
+        (message) => {
+          expect(message).toStrictEqual({
+            title: '引数が不足してるみたいだ。',
+            description:
+              '[元ネタ](https://twitter.com/yuki_yuigishi/status/1555557259798687744)'
+          });
+          return Promise.resolve();
+        }
+      )
+    );
+  });
+
   it('delete message', async () => {
     const fn = vi.fn();
     await responder.on(

--- a/src/service/command/meme.ts
+++ b/src/service/command/meme.ts
@@ -8,13 +8,14 @@ import type { MessageEvent } from '../../runner/index.js';
 import { dousurya } from './meme/dousurya.js';
 import { hukueki } from './meme/hukueki.js';
 import { lolicon } from './meme/lolicon.js';
+import { moeta } from './meme/moeta.js';
 import { n } from './meme/n.js';
 import { nigetane } from './meme/nigetane.js';
 import parse from 'cli-argparse';
 import { takopi } from './meme/takopi.js';
 import { web3 } from './meme/web3.js';
 
-const memes = [dousurya, hukueki, lolicon, n, takopi, nigetane, web3];
+const memes = [dousurya, hukueki, lolicon, n, takopi, nigetane, web3, moeta];
 const memesByCommandName: Record<
   string,
   MemeTemplate<string, string> | undefined

--- a/src/service/command/meme/moeta.ts
+++ b/src/service/command/meme/moeta.ts
@@ -1,4 +1,4 @@
-import { MemeTemplate } from '../../../model/meme-template.js';
+import type { MemeTemplate } from '../../../model/meme-template.js';
 
 export const moeta: MemeTemplate<never, never> = {
   commandNames: ['moeta', 'yuki'],

--- a/src/service/command/meme/moeta.ts
+++ b/src/service/command/meme/moeta.ts
@@ -1,0 +1,13 @@
+import { MemeTemplate } from '../../../model/meme-template.js';
+
+export const moeta: MemeTemplate<never, never> = {
+  commandNames: ['moeta', 'yuki'],
+  description: '久留米の花火大会ね、寮から見れたの?',
+  flagsKeys: [],
+  optionsKeys: [],
+  errorMessage:
+    '[元ネタ](https://twitter.com/yuki_yuigishi/status/1555557259798687744)',
+  generate(args) {
+    return `「久留米の花火大会ね、寮から見れたの?」\n「うん ついでに${args.body}が燃えた」\n「は?」`;
+  }
+};


### PR DESCRIPTION

### Type of Change:

追加 ( `MEME` )

### Details of implementation (実施内容)

我慢できなかった

[雪親と雪自身のLINEからインスパイアを受けた構文](https://twitter.com/yuki_yuigishi/status/1555557259798687744) を追加します。

```
!moeta(or yuki) えぬ

「久留米の花火大会ね、寮から見れたの?」
「うん ついでにえぬが燃えた」
「は?」
```


### Additional Information (追加情報)
