### PR TITLE
fix: Guild の available フィールドを確認するように修正

### DIFF
--- a/src/adaptor/discord/member-stats.ts
+++ b/src/adaptor/discord/member-stats.ts
@@ -20,16 +20,16 @@ export class DiscordMemberStats
 
   async allMemberCount(): Promise<number> {
     const guild = await this.client.guilds.fetch(this.guildId);
-    if (!guild) {
-      throw new Error('guild not found');
+    if (!guild.available) {
+      throw new Error('guild unavailable');
     }
     return guild.memberCount;
   }
 
   async botMemberCount(): Promise<number> {
     const guild = await this.client.guilds.fetch(this.guildId);
-    if (!guild) {
-      throw new Error('guild not found');
+    if (!guild.available) {
+      throw new Error('guild unavailable');
     }
     const guildMemberList = await guild.members.list({ limit: 1000 });
     return guildMemberList.filter((member) => member.user.bot).size;
@@ -37,8 +37,8 @@ export class DiscordMemberStats
 
   async fetchMembersWithRole(): Promise<MemberWithRole[]> {
     const guild = await this.client.guilds.fetch(this.guildId);
-    if (!guild) {
-      throw new Error('guild not found');
+    if (!guild.available) {
+      throw new Error('guild unavailable');
     }
     const guildMemberList = await guild.members.list({ limit: 1000 });
     return guildMemberList.map(({ displayName, roles }) => ({
@@ -49,6 +49,9 @@ export class DiscordMemberStats
 
   async fetchStats(userId: string): Promise<UserStats | null> {
     const guild = await this.client.guilds.fetch(this.guildId);
+    if (!guild.available) {
+      throw new Error('guild unavailable');
+    }
     const member = await guild.members.fetch(userId);
     if (!member) {
       return null;

--- a/src/adaptor/discord/role.ts
+++ b/src/adaptor/discord/role.ts
@@ -15,6 +15,9 @@ export class DiscordRoleManager implements RoleManager, RoleStatsRepository {
 
   async addRole(targetMember: Snowflake, newRoleId: Snowflake): Promise<void> {
     const guild = await this.client.guilds.fetch(this.guildId);
+    if (!guild.available) {
+      throw new Error('guild unavailable');
+    }
     const member = await guild.members.fetch(targetMember);
     await member.roles.add(newRoleId);
   }
@@ -24,12 +27,18 @@ export class DiscordRoleManager implements RoleManager, RoleStatsRepository {
     removingRoleId: Snowflake
   ): Promise<void> {
     const guild = await this.client.guilds.fetch(this.guildId);
+    if (!guild.available) {
+      throw new Error('guild unavailable');
+    }
     const member = await guild.members.fetch(targetMember);
     await member.roles.remove(removingRoleId);
   }
 
   async fetchStats(roleId: string): Promise<RoleStats | null> {
     const guild = await this.client.guilds.fetch(this.guildId);
+    if (!guild.available) {
+      throw new Error('guild unavailable');
+    }
     const role = await guild.roles.fetch(roleId);
     if (!role) {
       return null;

--- a/src/adaptor/discord/voice.ts
+++ b/src/adaptor/discord/voice.ts
@@ -38,9 +38,10 @@ export class DiscordVoiceConnectionFactory<K extends string | number | symbol>
     guildId: Snowflake,
     roomId: Snowflake
   ): Promise<VoiceConnection<K>> {
-    const guild =
-      this.client.guilds.cache.get(guildId) ||
-      (await this.client.guilds.fetch(guildId));
+    const guild = await this.client.guilds.fetch(guildId);
+    if (!guild.available) {
+      throw new Error('guild unavailable');
+    }
     const channel =
       guild.channels.cache.get(roomId) || (await guild.channels.fetch(roomId));
     if (!channel) {


### PR DESCRIPTION
### Type of Change:

コードの修正

### Details of implementation (実施内容)

discord.js のドキュメントにおいて [`Guild`](https://discord.js.org/#/docs/main/stable/class/Guild) を操作する前に [`available`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=available) フィールドを確認して利用可能かどうか確認することを推奨されていました. しかしコードにおいて確認を怠っていたため, その処理を追記しました.
