### PR TITLE
fix(ci): semantic-releaseのDocker認証エラーを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  workflow_dispatch:
   schedule:
     #        +---------------- minute (0 - 59)
     #        | +------------- hour (0 - 23)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - uses: docker/setup-buildx-action@v2.0.0
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_REGISTRY_USER: ${{ github.actor }}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
close #397 

### Type of Change:

修正(CI)

### Cause of the Problem (問題の原因)

[Release #84: Scheduled](https://github.com/approvers/OreOreBot2/actions/runs/2850598592) にて下記エラーが発生していました。

```shell
AggregateError: 
    SemanticReleaseError: Docker authentication failed
        at doLogin (/home/runner/work/OreOreBot2/OreOreBot2/node_modules/@codedependant/semantic-release-docker/lib/verify.js:79:21)
        at verify (/home/runner/work/OreOreBot2/OreOreBot2/node_modules/@codedependant/semantic-release-docker/lib/verify.js:56:11)
        at async validator (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/lib/plugins/normalize.js:34:24)
        at async /home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/lib/plugins/pipeline.js:37:34
        at async /home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/lib/plugins/pipeline.js:31:3
        at async Object.pluginsConf.<computed> [as verifyConditions] (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/lib/plugins/index.js:80:11)
        at async run (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/index.js:103:3)
        at async module.exports (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/index.js:269:22)
        at async module.exports (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/cli.js:55:5)
    at /home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/lib/plugins/pipeline.js:54:11
    at async Object.pluginsConf.<computed> [as verifyConditions] (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/lib/plugins/index.js:80:11)
    at async run (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/index.js:103:3)
    at async module.exports (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/index.js:269:22)
    at async module.exports (/home/runner/.npm/_npx/cdf31b77322f1d44/node_modules/semantic-release/cli.js:55:5)
Error: Process completed with exit code 1.
```

同時にgithub-actions(bot)が作成したIssue ( #397 ) にて **`DOCKER_REGISTORY_USER`, `DOCKER_REGISTORY_PASSWORD` が ENV versに追加する必要がある**との記載があったため、恐らくそもそもDockerへのログインに失敗しているのではと考えました。

### Dealing with Problems (問題への対処)

github-actions(bot)が作成したIssue ( #397 ) から、 [`release.yml`](https://github.com/approvers/OreOreBot2/compare/fix/docker-release?expand=1#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34)  の `Release` にそれぞれ `DOCKER_REGISTORY_USER`, `DOCKER_REGISTORY_PASSWORD` を参照するenvを追加しました。

----

(ここらへん知見があまりないので可笑しかったらどんどんchange request送ってください)