### PR TITLE
chore: dependabot version updatesの監視下にDockerのイメージを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,13 @@ updates:
     target-branch: main
     commit-message:
       prefix: chore(ci)
+  - package-ecosystem: 'docker'
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "m2en"
+      - "MikuroXina"
+    target-branch: main
+    commit-message:
+      prefix: chore(docker)


### PR DESCRIPTION
### Type of Change:

小規模変更

### Details of implementation (実施内容)

dependabot version updatesの対象パッケージエコシステムに `docker` を追加し、Dependabotの監視下に追加します。

これにより、[Dockerfile](https://github.com/approvers/OreOreBot2/blob/main/Dockerfile) 内で使用しているイメージにアップデートがある場合はDependabotがプルリクエストを作成するようになります。
