### PR TITLE
feat: VersionEmbedのデザインを変更

### DIFF
--- a/src/service/command/version.ts
+++ b/src/service/command/version.ts
@@ -29,8 +29,8 @@ export class GetVersionCommand implements CommandResponder {
     const { version } = this.fetcher;
     await message.reply({
       title: 'はらちょバージョン',
-      description: `${version} だよ。`,
-      url: `https://github.com/approvers/OreOreBot2/releases/tag/${version}`
+      description: `[${version}](https://github.com/approvers/OreOreBot2/releases/tag/${version}) だよ。`,
+      url: `https://github.com/approvers/OreOreBot2/releases`
     });
   }
 }


### PR DESCRIPTION
### Type of Change:

変更

### Details of implementation (実施内容)

![image](https://user-images.githubusercontent.com/82575685/185749737-6c424f66-5355-4014-9616-0609808087d8.png)

`!version` で表示されるEmbedのデザインを変更しました。

**はらちょバージョン** をクリックすると [リリースページ](https://github.com/approvers/OreOreBot2/releases) へ移動し、**各バージョン** をクリックするとその該当のリリースページへ移動します。
