### PR TITLE
fix: importsNotUsedAsValues を error に変更

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -48,7 +48,7 @@ import { DiscordSheriff } from '../adaptor/discord/sheriff.js';
 import { DiscordWS } from '../adaptor/discord/ws.js';
 import { GenVersionFetcher } from '../adaptor/version/fetch.js';
 import type { KaereMusicKey } from '../service/command/kaere.js';
-import { Snowflake } from '../model/id.js';
+import type { Snowflake } from '../model/id.js';
 import dotenv from 'dotenv';
 import { extractEnv } from './extract-env.js';
 import { generateDependencyReport } from '@discordjs/voice';

--- a/src/service/command.ts
+++ b/src/service/command.ts
@@ -3,8 +3,11 @@ import {
   PartyCommand,
   RandomGenerator as PartyRng
 } from './command/party.js';
-import { Clock, ScheduleRunner } from '../runner/schedule.js';
-import { CommandMessage, CommandResponder } from './command/command-message.js';
+import type { Clock, ScheduleRunner } from '../runner/schedule.js';
+import type {
+  CommandMessage,
+  CommandResponder
+} from './command/command-message.js';
 import { DebugCommand, MessageRepository } from './command/debug.js';
 import { GetVersionCommand, VersionFetcher } from './command/version.js';
 import { GuildInfo, GuildStatsRepository } from './command/guild-info.js';
@@ -23,10 +26,11 @@ import { RoleInfo, RoleStatsRepository } from './command/role-info.js';
 import { Sheriff, SheriffCommand } from './command/stfu.js';
 import { TypoReporter, TypoRepository } from './command/typo-record.js';
 import { UserInfo, UserStatsRepository } from './command/user-info.js';
+
 import { HelpCommand } from './command/help.js';
 import { Meme } from './command/meme.js';
-import { MessageResponseRunner } from '../runner/message.js';
-import { VoiceConnectionFactory } from './voice-connection.js';
+import type { MessageResponseRunner } from '../runner/message.js';
+import type { VoiceConnectionFactory } from './voice-connection.js';
 
 export const registerAllCommandResponder = ({
   typoRepo,

--- a/src/service/command/role-rank.ts
+++ b/src/service/command/role-rank.ts
@@ -3,7 +3,8 @@ import type {
   CommandResponder,
   HelpInfo
 } from './command-message.js';
-import { MessageEvent } from '../../runner/message.js';
+
+import type { MessageEvent } from '../../runner/message.js';
 
 export interface MemberWithRole {
   displayName: string;

--- a/src/service/kawaemon-has-all-roles.test.ts
+++ b/src/service/kawaemon-has-all-roles.test.ts
@@ -1,7 +1,8 @@
 import { KawaemonHasAllRoles, RoleManager } from './kawaemon-has-all-roles.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import type { Snowflake } from '../model/id.js';
-import { StandardOutput } from './output.js';
+import type { StandardOutput } from './output.js';
 
 const KAWAEMON_ID = '391857452360007680' as Snowflake;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "pretty": true,
     "newLine": "CRLF",
     "resolveJsonModule": true,
+    "importsNotUsedAsValues": "error",
     "typeRoots": ["./node_modules/@types", "./src/typings"]
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
### Type of Change:

tsconfig の変更

### Cause of the Problem (問題の原因)

これまでコードレビューにおいて `import type` を指摘していましたが, これでは作業効率が少し悪くなっていました.

### Details of implementation (実施内容)

`tsconfig.json` にて `importsNotUsedAsValues` を `error` に設定し, 値を `import` していない場合の通常の `import` はエラーになるようにしました.
