### PR TITLE
ci: hadolintによるDockerfileのIint CIを追加

### DIFF
--- a/.github/workflows/dockerfilelint-else.yml
+++ b/.github/workflows/dockerfilelint-else.yml
@@ -1,0 +1,15 @@
+name: dockerfile lint (else)
+
+on:
+  pull_request:
+    paths:
+      - ./Dockerfile
+
+jobs:
+  run_test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "No lint(dockerfile) required"
+

--- a/.github/workflows/dockerfilelint-else.yml
+++ b/.github/workflows/dockerfilelint-else.yml
@@ -6,8 +6,8 @@ on:
       - ./Dockerfile
 
 jobs:
-  run_test:
-    name: test
+  lint:
+    name: Dockerfile lint
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/dockerfilelint-else.yml
+++ b/.github/workflows/dockerfilelint-else.yml
@@ -2,7 +2,7 @@ name: dockerfile lint (else)
 
 on:
   pull_request:
-    paths:
+    paths-ignore:
       - ./Dockerfile
 
 jobs:

--- a/.github/workflows/dockerfilelint.yml
+++ b/.github/workflows/dockerfilelint.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: hadolint/hadolint-action@v2.1.0
+      - name: lint
+        uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: ./Dockerfile
           no-color: false
@@ -25,7 +26,7 @@ jobs:
         with:
           script: |
             const hadolintOutput = `
-            #### Hadolint: \`${{ steps.hadolint.outcome }}\`
+            #### Hadolint: \`${{ steps.lint.outcome }}\`
             \`\`\`
             ${process.env.HADOLINT_RESULTS}
             \`\`\`

--- a/.github/workflows/dockerfilelint.yml
+++ b/.github/workflows/dockerfilelint.yml
@@ -2,7 +2,7 @@ name: dockerfile lint
 
 on:
   pull_request:
-    branches:
+    paths:
       - ./Dockerfile
 
 jobs:

--- a/.github/workflows/dockerfilelint.yml
+++ b/.github/workflows/dockerfilelint.yml
@@ -1,0 +1,39 @@
+name: dockerfile lint
+
+on:
+  pull_request:
+    branches:
+      - ./Dockerfile
+
+jobs:
+  lint:
+    name: Dockerfile lint by Hadolint Action
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: hadolint/hadolint-action@v2.1.0
+        with:
+          dockerfile: ./Dockerfile
+          no-color: false
+          no-fail: false
+
+      - name: Create pull request comment
+        uses: actions/github-script@v6.2.0
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            const hadolintOutput = `
+            #### Hadolint: \`${{ steps.hadolint.outcome }}\`
+            \`\`\`
+            ${process.env.HADOLINT_RESULTS}
+            \`\`\`
+            `;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: hadolintOutput,
+            });

--- a/.github/workflows/dockerfilelint.yml
+++ b/.github/workflows/dockerfilelint.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: lint
-        uses: hadolint/hadolint-action@v2.1.0
+      - uses: hadolint/hadolint-action@v2.1.0
+        id: run_hadolint
         with:
           dockerfile: ./Dockerfile
           no-color: false
@@ -26,7 +26,7 @@ jobs:
         with:
           script: |
             const hadolintOutput = `
-            #### Hadolint: \`${{ steps.lint.outcome }}\`
+            #### Hadolint: \`${{ steps.run_hadolint.outcome }}\`
             \`\`\`
             ${process.env.HADOLINT_RESULTS}
             \`\`\`


### PR DESCRIPTION
close #444 

<!--
    このプルリクエストに関連し、マージ時に自動的にクローズしたいIssueの番号を記載します。
    複数のIssueを記載する場合は、改行で区切ってください。
    例:
    close #1
    close #2
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### Type of Change:

新規追加(CI)

### Details of implementation (実施内容)

#443 にて話題が上がったDockerfileの内容の検証を行うCIを追加しました。

Dockerfileが変更に上がっているプルリクエストに対し発動し、結果をプルリクエスト コメントに残します。

使用したWorkflowは [hadolint-action](https://github.com/hadolint/hadolint-action) です。

### Additional Information (追加情報)

eslintのようなルール設定がこのhadolintでも可能です。ですが、走らせたことがないため、とりあえず今のところは様子見で、今後必要になったらコンフィグ設定を行おうと思います。

https://github.com/hadolint/hadolint#configure