### PR TITLE
fix: predebug を predev に名称変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "merunno <merunno92@gmail.com>",
   "scripts": {
     "start": "node ./build/index.js",
-    "predebug": "yarn gen-version",
+    "predev": "yarn gen-version",
     "dev": "ts-node --esm ./src/server/index.ts",
     "gen-version": "make-dir build && git describe --tags --abbrev=0 > build/version.txt",
     "prebuild": "yarn gen-version",


### PR DESCRIPTION
### Type of Change:

npm スクリプトの修正

### Details of implementation (実施内容)

以前にデバッグ実行のスクリプト名を `debug` から `dev` へと変更した際に, `predebug` を `predev` へと変更し忘れていたので修正しました.
