### PR TITLE
fix: 大文字のHEXを指定した際にロールが正しく作成できない問題の修正

### DIFF
--- a/src/service/command/role-create.test.ts
+++ b/src/service/command/role-create.test.ts
@@ -39,6 +39,60 @@ describe('Create a role', () => {
     );
   });
 
+  it('create a role(lower case)', async () => {
+    const newRoleName = 'かわえもんのおねえさん';
+    const newRoleColor = 'faac9b'; //黒
+    const createGuildRole = vi.spyOn(manager, 'createRole');
+    const fn = vi.fn();
+
+    await createRole.on(
+      'CREATE',
+      createMockMessage(
+        {
+          args: ['rolecreate', newRoleName, newRoleColor]
+        },
+        fn
+      )
+    );
+
+    expect(fn).toHaveBeenCalledWith({
+      title: 'ロール作成',
+      description: 'ロールを作成したよ'
+    });
+    expect(createGuildRole).toHaveBeenCalledWith(
+      newRoleName,
+      newRoleColor,
+      'Mikuroさいな'
+    );
+  });
+
+  it('create a role(big letter)', async () => {
+    const newRoleName = 'かわえもんのおねえさん';
+    const newRoleColor = 'FAAC9B'; //黒
+    const createGuildRole = vi.spyOn(manager, 'createRole');
+    const fn = vi.fn();
+
+    await createRole.on(
+      'CREATE',
+      createMockMessage(
+        {
+          args: ['rolecreate', newRoleName, newRoleColor]
+        },
+        fn
+      )
+    );
+
+    expect(fn).toHaveBeenCalledWith({
+      title: 'ロール作成',
+      description: 'ロールを作成したよ'
+    });
+    expect(createGuildRole).toHaveBeenCalledWith(
+      newRoleName,
+      newRoleColor,
+      'Mikuroさいな'
+    );
+  });
+
   it('Missing argument(rolename)', async () => {
     const createGuildRole = vi.spyOn(manager, 'createRole');
     const fn = vi.fn();

--- a/src/service/command/role-create.ts
+++ b/src/service/command/role-create.ts
@@ -58,7 +58,7 @@ export class RoleCreate implements CommandResponder {
       return;
     }
 
-    if (!roleColor.match(/^#?[0-9a-f]{6}$/m)) {
+    if (!roleColor.match(/^#?[0-9a-fA-F]{6}$/m)) {
       await message.reply({
         title: 'コマンド形式エラー',
         description:

--- a/src/service/command/role-create.ts
+++ b/src/service/command/role-create.ts
@@ -26,7 +26,7 @@ export class RoleCreate implements CommandResponder {
       {
         name: 'ロールの色',
         description:
-          '作成するロールの色を[HEX](https://htmlcolorcodes.com/)で指定してね\n`#`はなしで指定してね'
+          '作成するロールの色を[HEX](https://htmlcolorcodes.com/)で指定してね'
       }
     ]
   };


### PR DESCRIPTION
### Type of Change:

修正

### Details of implementation (実施内容)

`!rolecreate` で大文字のHEX(例: #FAAC9B)を指定した際、本来作成される処理が正しく実行されない問題を修正しました。

また、 `#` を指定しても作成される仕様なのに、ヘルプの埋め込みの記載が間違っていたのでそれも修正しています。
(`s/#はなしで指定してね`)

### Additional Information (追加情報)

HEXが大文字・小文字、それぞれ追加した際のテストケースも同時に a89b69ec2c9b3464316d7ef44fbcd54afe54bbe0 で追加しています。