### PR TITLE
chore: GitHub Sponsorのボタンを表示するための設定ファイルを追加

### DIFF
--- a/.github/FANDING.yml
+++ b/.github/FANDING.yml
@@ -1,0 +1,1 @@
+github: [m2en, shun-shobon]


### PR DESCRIPTION
### Type of Change:

`.github/` 配下への設定ファイル追加

### Details of implementation (実施内容)

GitHub SponsorのSponsor Buttonを表示するための設定ファイルを追加します。

参考: [Displaying a sponsor button in your repository - GitHub Docs](https://docs.github.com/ja/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository)

@dependabot を除いた、過去に[OreOreBot2に貢献](https://github.com/approvers/OreOreBot2/graphs/contributors)し、かつGitHub Sponsorが有効になっている以下のメンバーのボタンを追加しています。

- @m2en 
- @shun-shobon 

### Additional Information (追加情報)

GitHub Sponsorに限らず、他の同じようなサービスのリンクを表示することも可能です。

- [IssueHunt](https://issuehunt.io/)
- [Ko-fi](https://ko-fi.com/)
- [Liberapay](https://en.liberapay.com/)
- [Open Collective](https://opencollective.com/)
- [Otechie](https://otechie.com/)
- [Patreon](https://www.patreon.com/)
- 任意のリンク

[OreOreBot2に貢献](https://github.com/approvers/OreOreBot2/graphs/contributors) したメンバーであれば追加してもいいかなと考えています。