### PR TITLE
ci: リリース時にタグを取得するように修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
### Type of Change:

CI の修正

### Details of implementation (実施内容)

実際のバージョンと `!version` が異なっていました. これは似たような前例から Docker パッケージのビルド時にタグを取得できていないことによるものと判断しました. そこでリリース CI で `fetch-depth: 0` を追記し, ブランチ/タグを全て取得するように変更しました.
