### PR TITLE
build: GIT_TAG 引数を用いてバージョンファイルを生成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM mwader/static-ffmpeg:5.1.1 as ffmpeg
 
 FROM node:18-slim as build
+ARG GIT_TAG
 SHELL ["/bin/bash", "-c"]
 WORKDIR /src
 
@@ -14,11 +15,12 @@ RUN apt-get update \
 COPY package.json yarn.lock ./
 RUN yarn
 COPY . .
-RUN yarn build
+RUN yarn build \
+    && echo $GIT_TAG > ./build/version.txt
 
 WORKDIR /build
-RUN cp -r /src/{build,assets,package.json,yarn.lock} . && \
-    yarn install --production=true
+RUN cp -r /src/{build,assets,package.json,yarn.lock} . \
+    && yarn install --production=true
 
 
 FROM gcr.io/distroless/nodejs:18


### PR DESCRIPTION
### Type of Change:

Dockerfile の修正

### Cause of the Problem (問題の原因)

リリース CI でタグを生成した場合に, それを push しているだけで CI 側で読めていませんでした.

### Dealing with Problems (問題への対処)

semantic-release-docker 側でビルド時に最新のタグの情報を渡してくれるので, これを使って手動で生成するようにしました.

### Additional Information (追加情報)

ついでに RUN の一部が他の記述と同じスタイルになっていなかったので合わせています.
