### PR TITLE
build: dockerArgs の追加

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,10 @@
           "v{{major}}.{{minor}}"
         ],
         "dockerRegistry": "ghcr.io",
-        "dockerProject": "approvers"
+        "dockerProject": "approvers",
+        "dockerArgs": {
+          "GIT_TAG": "{{git_tag}}"
+        }
       }
     ]
   ],


### PR DESCRIPTION
close #492.

### Type of Change:

設定の修正

### Details of implementation (実施内容)

Docker イメージのビルド時に引数が渡っていなかったようなので, `dockerArgs` の指定を追加してみました.
