### PR TITLE
feat: 短縮形エイリアスの追加

### DIFF
--- a/src/service/command/guild-info.ts
+++ b/src/service/command/guild-info.ts
@@ -70,7 +70,7 @@ export interface GuildStatsRepository {
 }
 
 const SCHEMA = {
-  names: ['guildinfo', 'serverinfo'],
+  names: ['guildinfo', 'serverinfo', 'guild', 'server'],
   subCommands: {}
 } as const;
 

--- a/src/service/command/role-info.test.ts
+++ b/src/service/command/role-info.test.ts
@@ -45,11 +45,6 @@ describe('RoleRank', () => {
           inline: true
         },
         {
-          name: '作成日時',
-          value: `<t:20200>`,
-          inline: true
-        },
-        {
           name: '所属人数',
           value: `3人`,
           inline: true
@@ -62,6 +57,11 @@ describe('RoleRank', () => {
         {
           name: 'カラーコード',
           value: '1a1d1a',
+          inline: true
+        },
+        {
+          name: '作成日時',
+          value: `<t:20200>(<t:20200:R>)`,
           inline: true
         }
       ],

--- a/src/service/command/role-info.ts
+++ b/src/service/command/role-info.ts
@@ -27,7 +27,7 @@ export interface RoleStatsRepository {
 }
 
 const SCHEMA = {
-  names: ['roleinfo'],
+  names: ['roleinfo', 'role'],
   subCommands: {},
   params: [
     {

--- a/src/service/command/role-info.ts
+++ b/src/service/command/role-info.ts
@@ -3,6 +3,7 @@ import type {
   CommandResponder,
   HelpInfo
 } from './command-message.js';
+import { createTimestamp } from '../../model/create-timestamp.js';
 
 export type RoleIcon =
   | {
@@ -66,16 +67,10 @@ export class RoleInfo implements CommandResponder<typeof SCHEMA> {
     { color, createdAt, icon, numOfMembersBelonged, position }: RoleStats,
     roleId: string
   ) {
-    const timeStampSeconds = Math.floor(createdAt.getTime() / 1000);
     const fields = [
       {
         name: 'ID',
         value: `${roleId}`,
-        inline: true
-      },
-      {
-        name: '作成日時',
-        value: `<t:${timeStampSeconds}>`,
         inline: true
       },
       {
@@ -91,6 +86,11 @@ export class RoleInfo implements CommandResponder<typeof SCHEMA> {
       {
         name: 'カラーコード',
         value: color,
+        inline: true
+      },
+      {
+        name: '作成日時',
+        value: createTimestamp(createdAt),
         inline: true
       }
     ];

--- a/src/service/command/user-info.ts
+++ b/src/service/command/user-info.ts
@@ -22,7 +22,7 @@ export interface UserStatsRepository {
 }
 
 const SCHEMA = {
-  names: ['userinfo'],
+  names: ['userinfo', 'user'],
   subCommands: {},
   params: [
     {


### PR DESCRIPTION
close #515 

### Type of Change:

新規追加

### Details of implementation (実施内容)

情報確認系のコマンドはとても長いため、実行しやすいように短縮したエイリアスを追加します。

今後この短縮形となる形のコマンドは追加されないと考え、プルリクエストを作成しました。(追加されたらまた考えます。)

- `!roleinfo` → `!role`
- `!guildinfo` → `!guild`
- `!userinfo` → `!user`

### Additional Information (追加情報)

追加で、 `!guildinfo` (ギルド情報コマンド) 使用時表示されるタイムスタンプに **実行された日時までの経過時間** が表示されてなかったため、(共通のメソッドが使われていない) 置き換えました。

この変更により、Embed Objectのサイズがデカくなり、表示がおかしくなることを回避するため、タイムスタンプの表示部分を最後に移動しました。

![image](https://user-images.githubusercontent.com/82575685/198837009-9d356091-a9a8-4d45-bace-14bd6c2bc6a0.png)
