### PR TITLE
fix: アスタリスク6つのみのメッセージを無視

### DIFF
--- a/src/service/bold-italic-cop.ts
+++ b/src/service/bold-italic-cop.ts
@@ -1,6 +1,7 @@
 import type { MessageEvent, MessageEventResponder } from '../runner/index.js';
 
-const boldItalic = /\*\*\*/g;
+// 一つでも含まれていればよいため、最短マッチを行う
+const boldItalic = /\*\*\*(?:.+?)\*\*\*/g;
 
 export interface BoldItalicCop {
   /**
@@ -25,7 +26,7 @@ export class BoldItalicCopReporter
     if (event !== 'CREATE') return;
     const boldItalicSize = message.content.match(boldItalic);
     if (!boldItalicSize) return;
-    if (boldItalicSize.length >= 2) {
+    if (boldItalicSize.length >= 1) {
       await message.replyMessage({
         content: 'Bold-Italic警察だ!!! <:haracho:684424533997912096>'
       });


### PR DESCRIPTION
fix #574

### Type of Change:
fix

### Cause of the Problem (問題の原因)
アスタリスク3つの列が2つ以上メッセージに含まれているかどうかを判定していたため、アスタリスク6つのみのケースでもマッチしていた

### Dealing with Problems (問題への対処)
条件をアスタリスク3つの列で囲われた部分が1文字以上あるかどうかに変更した

### Details of implementation (実施内容)
同上

### Additional Information (追加情報)
N/A
