### PR TITLE
fix: 絵文字のマッチパターンをより厳格に

### DIFF
--- a/assets/emoji-seq.yaml
+++ b/assets/emoji-seq.yaml
@@ -1,4 +1,4 @@
-- pattern: 響
+- pattern: (?<!影)響
   emojisToSend:
     - <:haracho:684424533997912096>
 - pattern: ぴちょん
@@ -12,7 +12,7 @@
 - pattern: 磯(崎|﨑)
   emojisToSend:
     - <:isozaki_kirito:836249519632023623>
-- pattern: カス
+- pattern: (?<![ァ-ヴー])カス(?![ァ-ヴー])
   emojisToSend:
     - <:ks:845281735897645066>
 - pattern: Python


### PR DESCRIPTION
### Type of Change:

パターン設定ファイルの修正

### Details of implementation (実施内容)

「影響」や「カスタム」など日常的な言葉でよくマッチしてしまっていたので, 否定先読み/後読みを使ってマッチしにくくしました.

- `響` は直前に `影` がないときにマッチします
- `カス` は直前と直後にカタカナ `[ァ-ヴー]` がないときにマッチします
