### PR TITLE
feat: タコピー構文に教員名を変更できるオプション`-c`を追加

### DIFF
--- a/src/service/command/meme.test.ts
+++ b/src/service/command/meme.test.ts
@@ -103,6 +103,25 @@ describe('meme', () => {
         ),
         (message) => {
           expect(message).toStrictEqual({
+            description: `こるく「いっそう、出して」\nりにあ「わ、わかんないっピ.......」`
+          });
+        },
+        {
+          senderName: 'りにあ'
+        }
+      )
+    );
+  });
+
+  it('use case of takopi (-f, -c)', async () => {
+    await responder.on(
+      createMockMessage(
+        parseStringsOrThrow(
+          ['takopi', '-f', '-c', 'こるく', 'いっそう'],
+          responder.schema
+        ),
+        (message) => {
+          expect(message).toStrictEqual({
             description: `りにあ「いっそう、出して」\nこるく「わ、わかんないっピ.......」`
           });
         },

--- a/src/service/command/meme.test.ts
+++ b/src/service/command/meme.test.ts
@@ -94,6 +94,25 @@ describe('meme', () => {
     );
   });
 
+  it('use case of takopi (-c)', async () => {
+    await responder.on(
+      createMockMessage(
+        parseStringsOrThrow(
+          ['takopi', '-c', 'こるく いっそう'],
+          responder.schema
+        ),
+        (message) => {
+          expect(message).toStrictEqual({
+            description: `りにあ「こるく、出して」\nいっそう「わ、わかんないっピ.......」`
+          });
+        },
+        {
+          senderName: 'りにあ'
+        }
+      )
+    );
+  });
+
   it('use case of n', async () => {
     await responder.on(
       createMockMessage(

--- a/src/service/command/meme.test.ts
+++ b/src/service/command/meme.test.ts
@@ -132,6 +132,20 @@ describe('meme', () => {
     );
   });
 
+  it('few arguments of takopi (-c)', async () => {
+    await responder.on(
+      createMockMessage(
+        parseStringsOrThrow(['takopi', '-c', 'こるく'], responder.schema),
+        (message) => {
+          expect(message).toStrictEqual({
+            description: '(引数が)わ、わかんないっピ.......',
+            title: '引数が不足してるみたいだ。'
+          });
+        }
+      )
+    );
+  });
+
   it('use case of n', async () => {
     await responder.on(
       createMockMessage(

--- a/src/service/command/meme.test.ts
+++ b/src/service/command/meme.test.ts
@@ -98,7 +98,7 @@ describe('meme', () => {
     await responder.on(
       createMockMessage(
         parseStringsOrThrow(
-          ['takopi', '-c', 'こるく いっそう'],
+          ['takopi', '-c', 'こるく', 'いっそう'],
           responder.schema
         ),
         (message) => {

--- a/src/service/command/meme.test.ts
+++ b/src/service/command/meme.test.ts
@@ -103,7 +103,7 @@ describe('meme', () => {
         ),
         (message) => {
           expect(message).toStrictEqual({
-            description: `りにあ「こるく、出して」\nいっそう「わ、わかんないっピ.......」`
+            description: `りにあ「いっそう、出して」\nこるく「わ、わかんないっピ.......」`
           });
         },
         {

--- a/src/service/command/meme/takopi.ts
+++ b/src/service/command/meme/takopi.ts
@@ -1,15 +1,19 @@
 import type { MemeTemplate } from '../../../model/meme-template.js';
 
-const takopiFlags = ['f'] as const;
+const takopiFlags = ['f', 'c'] as const;
 
 export const takopi: MemeTemplate<typeof takopiFlags[number], never> = {
   commandNames: ['takopi'],
   description:
-    '「〜、出して」\n`-f` で教員と自分の名前の位置を反対にします。([idea: フライさん](https://github.com/approvers/OreOreBot2/issues/90))',
+    '「〜、出して」\n`-f` で教員と自分の名前の位置を反対にします。\n`-c`で教員の名前も変更可能です。\n([idea: フライさん](https://github.com/approvers/OreOreBot2/issues/90))',
   flagsKeys: takopiFlags,
   optionsKeys: [],
   errorMessage: '(引数が)わ、わかんないっピ.......',
   generate(args, author) {
+    if (args.flags.c)
+      return `${author}「${args.body.split(' ')[0]}、出して」\n${
+        args.body.split(' ')[1]
+      }「わ、わかんないっピ.......」`;
     if (args.flags.f)
       return `${author}「${args.body}、出して」\n教員「わ、わかんないっピ.......」`;
     return `教員「${args.body}、出して」\n${author}「わ、わかんないっピ.......」`;

--- a/src/service/command/meme/takopi.ts
+++ b/src/service/command/meme/takopi.ts
@@ -12,7 +12,7 @@ export const takopi: MemeTemplate<
   description:
     '「〜、出して」\n`-f` で教員と自分の名前の位置を反対にします。\n`-c`で教員の名前も変更可能です。\n([idea: フライさん](https://github.com/approvers/OreOreBot2/issues/90))',
   flagsKeys: takopiFlags,
-  optionsKeys: [],
+  optionsKeys: takopiOptions,
   errorMessage: '(引数が)わ、わかんないっピ.......',
   generate(args, author) {
     if (args.options.c)

--- a/src/service/command/meme/takopi.ts
+++ b/src/service/command/meme/takopi.ts
@@ -1,8 +1,13 @@
 import type { MemeTemplate } from '../../../model/meme-template.js';
 
-const takopiFlags = ['f', 'c'] as const;
+const takopiFlags = ['f'] as const;
+//waiting merge #586
+const takopiOptions = ['c'] as const;
 
-export const takopi: MemeTemplate<typeof takopiFlags[number], never> = {
+export const takopi: MemeTemplate<
+  typeof takopiFlags[number],
+  typeof takopiOptions[number]
+> = {
   commandNames: ['takopi'],
   description:
     '「〜、出して」\n`-f` で教員と自分の名前の位置を反対にします。\n`-c`で教員の名前も変更可能です。\n([idea: フライさん](https://github.com/approvers/OreOreBot2/issues/90))',
@@ -10,10 +15,8 @@ export const takopi: MemeTemplate<typeof takopiFlags[number], never> = {
   optionsKeys: [],
   errorMessage: '(引数が)わ、わかんないっピ.......',
   generate(args, author) {
-    if (args.flags.c)
-      return `${author}「${args.body.split(' ')[0]}、出して」\n${
-        args.body.split(' ')[1]
-      }「わ、わかんないっピ.......」`;
+    if (args.options.c)
+      return `${author}「${args.body}、出して」\n${args.options.c}「わ、わかんないっピ.......」`;
     if (args.flags.f)
       return `${author}「${args.body}、出して」\n教員「わ、わかんないっピ.......」`;
     return `教員「${args.body}、出して」\n${author}「わ、わかんないっピ.......」`;

--- a/src/service/command/meme/takopi.ts
+++ b/src/service/command/meme/takopi.ts
@@ -9,7 +9,7 @@ export const takopi: MemeTemplate<
 > = {
   commandNames: ['takopi'],
   description:
-    '「〜、出して」\n`-f` で教員と自分の名前の位置を反対にします。\n`-c`で教員の名前も変更可能です。\n([idea: フライさん](https://github.com/approvers/OreOreBot2/issues/90))',
+    '「〜、出して」\n`-f` で教員と自分の名前の位置を反対にします。\n`-c <教員の名前> <出すもの>`で教員の名前も変更可能です。\n([idea: フライさん](https://github.com/approvers/OreOreBot2/issues/90))',
   flagsKeys: takopiFlags,
   optionsKeys: takopiOptions,
   errorMessage: '(引数が)わ、わかんないっピ.......',

--- a/src/service/command/meme/takopi.ts
+++ b/src/service/command/meme/takopi.ts
@@ -1,7 +1,6 @@
 import type { MemeTemplate } from '../../../model/meme-template.js';
 
 const takopiFlags = ['f'] as const;
-//waiting merge #586
 const takopiOptions = ['c'] as const;
 
 export const takopi: MemeTemplate<

--- a/src/service/command/meme/takopi.ts
+++ b/src/service/command/meme/takopi.ts
@@ -14,10 +14,17 @@ export const takopi: MemeTemplate<
   optionsKeys: takopiOptions,
   errorMessage: '(引数が)わ、わかんないっピ.......',
   generate(args, author) {
-    if (args.options.c)
-      return `${author}「${args.body}、出して」\n${args.options.c}「わ、わかんないっピ.......」`;
-    if (args.flags.f)
-      return `${author}「${args.body}、出して」\n教員「わ、わかんないっピ.......」`;
-    return `教員「${args.body}、出して」\n${author}「わ、わかんないっピ.......」`;
+    const takopiArgs = {
+      takopi: author,
+      shizuka: args.options.c ?? '教員',
+      goods: args.body ?? '課題'
+    };
+
+    if (args.flags.f) {
+      const temp: string = takopiArgs.takopi;
+      takopiArgs.takopi = takopiArgs.shizuka;
+      takopiArgs.shizuka = temp;
+    }
+    return `${takopiArgs.shizuka}「${takopiArgs.goods}、出して」\n${takopiArgs.takopi}「わ、わかんないっピ.......」`;
   }
 };


### PR DESCRIPTION
close #150 

<!--
    このプルリクエストに関連し、マージ時に自動的にクローズしたいIssueの番号を記載します。
    複数のIssueを記載する場合は、改行で区切ってください。
    例:
    close #1
    close #2
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### Type of Change:

<!--
    案を実現するためにどういうタイプの変更を行ったのか
    e.g. 修正(fix), 新規追加(feat), 破壊的変更　など
-->
タコピー構文にて、`-c`オプションで教員側の名称も任意にできる機能を追加しました。
![image](https://user-images.githubusercontent.com/44018535/204061102-b3382735-0301-4976-9c3f-698ed480d2e5.png)

### Details of implementation (実施内容)

- `-c` をオプション引数として実装
- オプションとフラグの同時使用に対応できるようにリファクタを行いました。 `-c -f`のように使用できます 
