### PR TITLE
feat(meme): 短いオプションのキーが使えるように

### DIFF
--- a/src/service/command/meme.ts
+++ b/src/service/command/meme.ts
@@ -47,7 +47,11 @@ export class Meme implements CommandResponder<typeof SCHEMA> {
       return;
     }
     const sanitizedArgs = sanitizeArgs(commandArgs);
-    const { flags, options, unparsed } = parse(sanitizedArgs);
+    const hyphen = (key: string) => (key.length <= 1 ? `-${key}` : `--${key}`);
+    const { flags, options, unparsed } = parse(sanitizedArgs, {
+      flags: meme.flagsKeys.map(hyphen),
+      options: meme.optionsKeys.map(hyphen)
+    });
     const body = unparsed.join(' ');
     if (flags['help'] || options['help']) {
       await message.reply({


### PR DESCRIPTION
### Type of Change:

Meme の機能追加

### Details of implementation (実施内容)

`MemeTemplate` の `optionsKeys` に `c` などの一文字だけを使ったり `flagsKeys` に `verbose` などの 2 文字以上の文字列を指定しても正しく動作するようになりました.

### Additional Information (追加情報)

#585 をより簡潔にするための機能です. なるべく早くレビューが欲しいです.
