### PR TITLE
ci(release): レポジトリによる実行条件の追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    if: github.repository == 'approvers/OreOreBot2'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Type of Change:

CI ワークフローの修正

### Cause of the Problem (問題の原因)

Release アクションが cron で動作しているので, フォークしたリポジトリでも動作していました.

### Dealing with Problems (問題への対処)

暫定的な対処として, ジョブにリポジトリの一致条件を追加して, フォークしたリポジトリでは動作しないようにしました.

### Additional Information (追加情報)

そもそもリリースを定期実行するのではなく, 定期的に「リリース PR」を作成し, それがマージされることでリリースを起動するようにしたほうがいいかもしれません. このほうが `package.json` のバージョンの不整合なども解消できます.
