### PR TITLE
fix: バージョンの読み取り先を `package.json` へ変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,15 @@ SHELL ["/bin/bash", "-c"]
 WORKDIR /src
 
 # node-gyp requires Python and basic packages needed to compile C libs
-# git is needed for `yarn gen-version`
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3=3.9.2-3 build-essential=12.9 git=1:2.30.2-1 \
+    && apt-get install -y --no-install-recommends python3=3.9.2-3 build-essential=12.9 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY package.json yarn.lock ./
 RUN yarn
 COPY . .
-RUN yarn build \
-    && echo $GIT_TAG > ./build/version.txt
+RUN yarn build
 
 WORKDIR /build
 RUN cp -r /src/{build,assets,package.json,yarn.lock} . \

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
   "author": "approvers <info@approvers.dev>",
   "scripts": {
     "start": "node ./build/index.js",
-    "predev": "yarn gen-version",
     "dev": "ts-node --esm ./src/server/index.ts",
-    "gen-version": "make-dir build && git describe --tags --abbrev=0 > build/version.txt",
-    "prebuild": "yarn gen-version",
     "build": "esbuild ./src/server/index.ts --bundle --platform=node  --target=node16 --format=esm --external:./node_modules/* --outfile=build/index.js",
     "format": "prettier --write \"src/**/*.{js,ts,md}\"",
     "check": "prettier --check \"src/**/*.{js,ts,md}\" && tsc -p . --noEmit",

--- a/src/adaptor/version/fetch.ts
+++ b/src/adaptor/version/fetch.ts
@@ -1,12 +1,10 @@
 import type { VersionFetcher } from '../../service/command/version.js';
-import { readFileSync } from 'node:fs';
+import pkg from '../../../package.json';
 
 export class GenVersionFetcher implements VersionFetcher {
   public readonly version: string;
 
   constructor() {
-    this.version = readFileSync('./build/version.txt')
-      .toString('utf-8', 0, 100)
-      .trim();
+    this.version = pkg.version;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ESNext",
     "module": "node16",
     "outDir": "./build",
-    "rootDir": "./src",
+    "rootDir": ".",
     "noEmit": true,
     "removeComments": true,
     "skipLibCheck": true,
@@ -24,5 +24,6 @@
     "importsNotUsedAsValues": "error",
     "typeRoots": ["./node_modules/@types", "./src/typings"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Close #613.

### Type of Change:

コードの修正, ビルドスクリプトの修正

### Details of implementation (実施内容)

release-please の採用により `package.json` の `version` フィールドが最新バージョンを指すようになったため, バージョンの読み取りを `package.json` から行うようにしました.

また, 型検査の都合で `tsconfig.json` の `rootDir` を `.` に書き換えています.
