### PR TITLE
ci: Trivy Scan CIのWorkflow Nameを正常なものに修正

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   scan:
-    name: build docker image
+    name: Scan by Trivy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Type of Change:

修正(CI)

### Details of implementation (実施内容)

ビルドとスキャンまで行う一連のワークフローの名称が `build docker image` になっていたので `Scan by Trivy` に修正し、意味が通るようにしました。