### PR TITLE
ci(fix): Trivy CI - Workflow のトリガーとなるプッシュの対象ブランチ名を修正

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -6,7 +6,7 @@ name: trivy scan
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION

### Type of Change:

修正(CI)

### Details of implementation (実施内容)

approvers/OreOreBot2 のデフォルトブランチ名は `main` ですが、Trivy CIの対象ブランチが `master` になっていたので修正しました。