### PR TITLE
build: 接頭辞 `v` を戻す

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -43,6 +43,6 @@ runs:
         tags: |
           ghcr.io/approvers/oreorebot2:latest
           ghcr.io/approvers/oreorebot2:${{ inputs.sha }}
-          ghcr.io/approvers/oreorebot2:${{ inputs.major }}
-          ghcr.io/approvers/oreorebot2:${{ inputs.major }}.${{ inputs.minor }}
-          ghcr.io/approvers/oreorebot2:${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}
+          ghcr.io/approvers/oreorebot2:v${{ inputs.major }}
+          ghcr.io/approvers/oreorebot2:v${{ inputs.major }}.${{ inputs.minor }}
+          ghcr.io/approvers/oreorebot2:v${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}


### PR DESCRIPTION
### Type of Change:

カスタムアクションの修正

### Details of implementation (実施内容)

タグから `v` の接頭辞が消えていたのを修正します.
