### PR TITLE
ci(fix): Dependabot のコミットに対する Trivy CI が失敗してしまう問題の修正

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -5,8 +5,11 @@ name: trivy scan
 # プッシュ時とプルリクエスト時に実行する
 on:
   push:
-    branches:
-      - main
+    # Dependabot のプッシュでの Workflows は読み取り専用権限として実行される
+    # 上記の場合、Code Scanning は使用できないため Dependabot のプッシュはスキャン対象に含めない
+    - '!dependabot/**/main/**'
+    - main
+  # プルリクエストは今まで通り、Dependabot のコミットであってもスキャン可能
   pull_request:
 
 jobs:
@@ -23,12 +26,12 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.8.0
         with:
-          image-ref: "oreorebot2"
-          format: "sarif"
+          image-ref: 'oreorebot2'
+          format: 'sarif'
           security-checks: vuln
-          output: "trivy-results.sarif"
+          output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: "trivy-results.sarif"
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -7,8 +7,9 @@ on:
   push:
     # Dependabot のプッシュでの Workflows は読み取り専用権限として実行される
     # 上記の場合、Code Scanning は使用できないため Dependabot のプッシュはスキャン対象に含めない
-    - '!dependabot/**/main/**'
-    - main
+    branches:
+      - '!dependabot/**/main/**'
+      - main
   # プルリクエストは今まで通り、Dependabot のコミットであってもスキャン可能
   pull_request:
 


### PR DESCRIPTION

### Type of Change:

修正

### Cause of the Problem (問題の原因)

@dependabot のコミットは GitHub Actions の仕様上、 読み取り専用として動作するため Code Scanning の結果をアップロードすることができない。

そのため Trivy CI にてスキャンした結果をアップロードできず、CIが落ちてしまっていた。

### Dealing with Problems (問題への対処)

上記問題を解決する案として以下のものがあげられたが、今回のエラーが推奨している方法で対処した

1. Workflowに書き込み権限を与える
2. @dependabot のブランチに対するプッシュは無視する

> Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, **please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches**. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

### Details of implementation (実施内容)

@dependabot は依存関係アップデートの際 `dependabot/<ecosystem>/<branch>/<dependency>` をブランチとして作業する ( 参考: #646 ) ので、`on.push.branches` にて `!` を付けて無視するブランチとして定義した。

プルリクエストに対するトリガーには権限が与えられるため、スキャンは実行される。

[### Additional Information (追加情報)](https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push)
