### PR TITLE
chore: renovate のタイムゾーンを明確に

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,5 +34,6 @@
       "m2en", "MikuroXina"
     ]
   },
+  "extends": [":timezone(Asia/Tokyo)"],
   "schedule": ["on the first day of the week"]
 }


### PR DESCRIPTION
### Details of implementation (実施内容)

#652 にて @mirror-kt に指摘された状態で Automerge が発動してしまい修正できずマージされてしまったため、このプルリクエストにて変更します。

なお、デフォルト値が再設定されていることについては現状 renovate 側から何も警告されていないので、今は特に気に留めず無視したいと思います。