### PR TITLE
fix: ヘルプコマンドのボタンをコマンド発行者しか押せないように修正

### DIFF
--- a/src/service/command/command-message.ts
+++ b/src/service/command/command-message.ts
@@ -4,6 +4,22 @@ import type { ParsedSchema, Schema } from '../../model/command-schema.js';
 import type { Snowflake } from '../../model/id.js';
 
 /**
+ * `CommandMessage.replyPages` のオプション。
+ *
+ * @export
+ * @interface ReplyPagesOptions
+ */
+export interface ReplyPagesOptions {
+  /**
+   * ページネーションのボタンを操作できるユーザの ID のリスト。
+   *
+   * @type {readonly Snowflake[]}
+   * @memberof ReplyPagesOptions
+   */
+  readonly usersCanPaginate?: readonly Snowflake[];
+}
+
+/**
  * コマンド形式のメッセージの抽象。
  *
  * @export
@@ -73,7 +89,7 @@ export interface CommandMessage<S extends Schema> {
    * @param pages
    * @memberof CommandMessage
    */
-  replyPages(pages: EmbedPage[]): Promise<void>;
+  replyPages(pages: EmbedPage[], options?: ReplyPagesOptions): Promise<void>;
 
   /**
    * このメッセージに `emoji` の絵文字でリアクションする。

--- a/src/service/command/help.ts
+++ b/src/service/command/help.ts
@@ -29,7 +29,9 @@ export class HelpCommand implements CommandResponder<typeof SCHEMA> {
     const pages: EmbedPage[] = helpAndSchema.map((helpScheme) =>
       this.buildField(helpScheme)
     );
-    await message.replyPages(pages);
+    await message.replyPages(pages, {
+      usersCanPaginate: [message.senderId]
+    });
   }
 
   private buildField({


### PR DESCRIPTION
close #656

<!--
    このプルリクエストに関連し、マージ時に自動的にクローズしたいIssueの番号を記載します。
    複数のIssueを記載する場合は、改行で区切ってください。
    例:
    close #1
    close #2
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### Type of Change:

機能の追加, 仕様変更

### Details of implementation (実施内容)

`replyPages` 関数に `ReplyPagesOptions` 型のオプションオブジェクトの引数を追加しました. また, これを利用してヘルプコマンドのボタンをコマンド発行者しか押せないように修正しました.
