### PR TITLE
ci: `github.actor` を利用しつつ処理を単純化

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -17,26 +17,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18'
-        cache: yarn
-
-    - name: Install dependencies
-      shell: bash
-      run: yarn install --immutable
-
-    - uses: docker/setup-buildx-action@v2.2.1
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2.2.1
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        username: ${{ github.actor }}
         password: ${{ github.token }}
     - name: Build and push
       uses: docker/build-push-action@v3


### PR DESCRIPTION
### Type of Change:

CI の修正

### Details of implementation (実施内容)

`ghcr.io` へログインするユーザ名を `github.actor`, つまりマージコミットした者に変更しました. また, Checkout や `yarn install` といった処理が不要だったので除去しました.
