### PR TITLE
fix: break embed links displayed in `!version`

### DIFF
--- a/src/service/command/version.ts
+++ b/src/service/command/version.ts
@@ -26,7 +26,11 @@ export class GetVersionCommand implements CommandResponder<typeof SCHEMA> {
     const { version } = this.fetcher;
     await message.reply({
       title: 'はらちょバージョン',
-      description: `[${version}](https://github.com/approvers/OreOreBot2/releases/tag/${version}) だよ。`,
+      /**
+       * v1.30.0以降、全てのTagの先頭には "oreorebot2-" という文字列が付与されるようになったため、ハードコーディングで対応
+       * https://github.com/approvers/OreOreBot2/tags
+       */
+      description: `[${version}](https://github.com/approvers/OreOreBot2/releases/tag/oreorebot2-v${version}) だよ。`,
       url: `https://github.com/approvers/OreOreBot2/releases`
     });
   }


### PR DESCRIPTION
close #677 

<!--
    このプルリクエストに関連し、マージ時に自動的にクローズしたいIssueの番号を記載します。
    複数のIssueを記載する場合は、改行で区切ってください。
    例:
    close #1
    close #2
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### Type of Change:

修正( `!version` )

### Cause of the Problem (問題の原因)

v1.30.0 ( #634 ) 以降、はらちょのタグには `oreorebot-` という文字列が最初につくようになっています。

`!version` を使うと埋め込みには [最新版のリリースページ](https://github.com/approvers/OreOreBot2/releases/latest) と そのビルドが運用しているバージョンのリリースページ へのリンクが埋め込みに表示されます。このリンクに使われるバージョン(タグ)の取得を行う `src/adaptor/fetch.ts` では package.json の `"version"` を取得していますが、 package.json には `oreorebot-` という文字列はついていないため、リンクが壊れて 404 になってしまっていました。

https://github.com/approvers/OreOreBot2/blob/ee078faa4b9fc9b4dc1d14a67628f1d544910d02/src/adaptor/version/fetch.ts#L4-L9

![CleanShot 2023-01-23 at 02 51 56@2x](https://user-images.githubusercontent.com/82575685/213931718-f381eb8f-4f81-4d02-a42e-8fe518abcdc0.jpg)


### Dealing with Problems (問題への対処)

`src/adaptor/fetch.ts` でコンストラクタに渡す値に直接 `oreorebot2-` と文字列を埋め込もうとしましたが、 package.json から値を取得しているものに手を加えるのは適しているとは思わないので `src/service/command/version.ts` の埋め込みのプロパティに手を加えました。

https://github.com/approvers/OreOreBot2/blob/1dd349c9f7d607cbc721bc22b2ebd31a94629ec8/src/service/command/version.ts#L29-L34

### Details of implementation (実施内容)

上記の通り

### Additional Information (追加情報)

CI側を変えるのもありかもしれません。そもそも文字列をなくしてしまう...?
