### PR TITLE
ci: 変更されたファイル名の中にアスタリスクが含まれていたら拒否する

### DIFF
--- a/.github/workflows/invalid-character-checker-for-ntfs.yml
+++ b/.github/workflows/invalid-character-checker-for-ntfs.yml
@@ -18,6 +18,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+# 変更されたファイル名の中にアスタリスクが含まれていたら拒否する
+
 name: Invalid character checker for NTFS
 on:
   - pull_request

--- a/.github/workflows/invalid-character-checker-for-ntfs.yml
+++ b/.github/workflows/invalid-character-checker-for-ntfs.yml
@@ -1,0 +1,38 @@
+# This file is licensed under MIT License.
+# Copyright 2023 Kisaragi Marine, KisaragiEffective
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the
+# following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+name: Invalid character checker for NTFS
+on:
+  - pull_request
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout all revision
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Check
+      run: |
+        if git diff "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}" --name-only | xargs basename | grep -E '.*\*.*'; then
+          echo "Asterisks cannot be appeared in file names, because they cannot be created with its name on Windows (more generally, on NTFS)." >&2
+          exit 1
+        fi


### PR DESCRIPTION
close #185

### Type of Change:
CI

### Cause of the Problem (問題の原因)
NTFSがアスタリスクを含むファイル名でファイルを作成することを許可しないこと

### Dealing with Problems (問題への対処)
アスタリスクを含むファイル名が検知されたら落ちるCIを導入

### Details of implementation (実施内容)
GitHub Actionsの追加

### Additional Information (追加情報)
デバッグのためにファイル名の一覧を表示している
