### PR TITLE
ci: Renovate の自動マージの設定を改善

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,13 +2,15 @@
   "reviewers": ["m2en", "MikuroXina"],
   "ignoreTests": false,
   "automerge": true,
+  "major": {
+    "automerge": false
+  },
+  "platformAutomerge": true,
+  "prConcurrentLimit": 5,
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "fetchReleaseNotes": true,
   "enabledManagers": ["npm", "github-actions", "dockerfile", "docker-compose"],
-  "major": {
-    "automerge": false
-  },
   "packageRules": [
     {
       "matchDatasources": ["npm"],


### PR DESCRIPTION
### Details of implementation (実施内容)

`platformAutomerge` を `true` にすることで GitHub の Auto-merge を利用するようにしました. また, `prConcurrentLimit` を 5 つにして, (セキュリティ関連を除いて) 同時に 5 つまでしか更新 PR が発生しないようにしました.

### Additional Information

自動マージの際の Approve の問題は [Renovate Approve](https://github.com/apps/renovate-approve) を使えば解決できます. 既に導入リクエスト済みなので管理者の承認待ちです.
