### PR TITLE
fix: 絵文字の作成者を取得するように修正

### DIFF
--- a/src/adaptor/proxy/emoji.ts
+++ b/src/adaptor/proxy/emoji.ts
@@ -1,5 +1,6 @@
 import type { Client } from 'discord.js';
 
+import type { Snowflake } from '../../model/id.js';
 import type { EmojiEventProvider } from '../../runner/index.js';
 import type { EmojiData } from '../../service/emoji-log.js';
 
@@ -9,11 +10,12 @@ export class EmojiProxy implements EmojiEventProvider<EmojiData> {
   constructor(private readonly client: Client) {}
 
   onEmojiCreate(handler: EmojiHandler<EmojiData>): void {
-    this.client.on('emojiCreate', (emoji) =>
-      handler({
+    this.client.on('emojiCreate', async (emoji) => {
+      const author = await emoji.fetchAuthor();
+      await handler({
         emoji: emoji.toString(),
-        emojiAuthorId: emoji.author?.id ?? undefined
-      })
-    );
+        emojiAuthorId: author.id as Snowflake
+      });
+    });
   }
 }

--- a/src/service/emoji-log.ts
+++ b/src/service/emoji-log.ts
@@ -1,9 +1,10 @@
+import type { Snowflake } from '../model/id.js';
 import type { EmojiEventResponder, RoleEvent } from '../runner/index.js';
 import type { StandardOutput } from './output.js';
 
 export interface EmojiData {
   emoji: string;
-  emojiAuthorId: string | undefined;
+  emojiAuthorId: Snowflake;
 }
 
 export class EmojiLog implements EmojiEventResponder<EmojiData> {


### PR DESCRIPTION
Closes #689.

### Type of Change:

コードの修正

### Cause of the Problem (問題の原因)

Discord.js の API を再確認したところ `emoji.fetchAuthor()` が存在しており, プログラムの目的としてもこちらを使うのが正しいようでした.

### Details of implementation (実施内容)

アダプタの実装は `fetchAuthor()` を利用するように修正し, あわせて `interface EmojiData` の `emojiAuthorId` の型を `Snowflake` にしておきました.
