### PR TITLE
ci: 不正なイメージ名の除去

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -25,7 +25,6 @@ runs:
       uses: docker/metadata-action@v4
       with:
         images: |
-          approvers/oreorebot2
           ghcr.io/approvers/oreorebot2
         tags: |
           type=schedule


### PR DESCRIPTION
### Type of Change:

CI の修正

### Details of implementation (実施内容)

`ghcr.io` がついていないイメージを指定すると Docker Hub に push してしまうようなので, `images` から除去しました.
