### PR TITLE
feat: 首相の否定的な考えMEMEを追加

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [m2en, shun-shobon]
+github: [m2en, shun-shobon, su8ru]

--- a/src/service/command/meme/index.ts
+++ b/src/service/command/meme/index.ts
@@ -8,6 +8,7 @@ import { n } from './n.js';
 import { nigetane } from './nigetane.js';
 import { nine } from './nine.js';
 import { ojaru } from './ojaru.js';
+import { syakai } from './syakai.js';
 import { takopi } from './takopi.js';
 import { tsureteike } from './tsureteike.js';
 import { web3 } from './web3.js';
@@ -25,5 +26,6 @@ export const memes = [
   koume,
   ojaru,
   nine,
-  tsureteike
+  tsureteike,
+  syakai
 ];

--- a/src/service/command/meme/syakai.ts
+++ b/src/service/command/meme/syakai.ts
@@ -1,0 +1,12 @@
+import type { MemeTemplate } from '../../../model/meme-template.js';
+
+export const syakai: MemeTemplate<never, never> = {
+  commandNames: ['syakai'],
+  description: '「首相、～に否定的な考え ― 『社会が変わってしまう』」',
+  flagsKeys: [],
+  optionsKeys: [],
+  errorMessage: '極めて慎重に検討すべき課題だ',
+  generate(args) {
+    return `「首相、${args.body}に否定的な考え ― 『社会が変わってしまう』」`;
+  }
+};

--- a/src/service/command/meme/test/syakai.test.ts
+++ b/src/service/command/meme/test/syakai.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseStringsOrThrow } from '../../../../adaptor/proxy/command/schema.js';
+import { createMockMessage } from '../../command-message.js';
+import { Meme } from '../../meme.js';
+
+describe('meme', () => {
+  const responder = new Meme();
+
+  it('use case of syakai', async () => {
+    await responder.on(
+      createMockMessage(
+        parseStringsOrThrow(['syakai', 'Rust採用'], responder.schema),
+        (message) => {
+          expect(message).toStrictEqual({
+            description:
+              '「首相、Rust採用に否定的な考え ― 『社会が変わってしまう』」'
+          });
+        }
+      )
+    );
+  });
+
+  it('args null (syakai)', async () => {
+    await responder.on(
+      createMockMessage(
+        parseStringsOrThrow(['syakai'], responder.schema),
+        (message) => {
+          expect(message).toStrictEqual({
+            title: '引数が不足してるみたいだ。',
+            description: '極めて慎重に検討すべき課題だ'
+          });
+        }
+      )
+    );
+  });
+});


### PR DESCRIPTION
### Type of Change:

新規追加 (MEME)

### Details of implementation (実施内容)

@su8ru が times であげていたコードを勝手にMEME化しました。ちゃんと草は彼にあげます。

`!syakai Rust採用` >> `「首相、Rust採用に否定的な考え ― 『社会が変わってしまう』」`
