### PR TITLE
build: pinst を用いた husky install の無効化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,14 @@ COPY .yarn/releases/ ./.yarn/releases/
 COPY package.json yarn.lock .yarnrc.yml ./
 
 RUN npx --quiet pinst --disable \
-    && yarn install --immutable
+    && yarn install --immutable --production=true \
+    && yarn cache clean
 
 COPY . .
 RUN yarn build
 
 WORKDIR /build
-RUN cp -r /src/{build,assets,package.json,yarn.lock} . \
-    && yarn install --immutable --production=true
-
+RUN cp -r /src/{build,assets,package.json,yarn.lock} .
 
 FROM ubuntu:jammy-20221130
 COPY --from=build /usr/local/include/ /usr/local/include/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY .yarn/releases/ ./.yarn/releases/
 COPY package.json yarn.lock .yarnrc.yml ./
 
 RUN npx --quiet pinst --disable \
-    && yarn install --immutable --production=true \
+    && yarn install --immutable \
     && yarn cache clean
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
 COPY .yarn/releases/ ./.yarn/releases/
 COPY package.json yarn.lock .yarnrc.yml ./
 
-RUN yarn install --immutable
+RUN npx --quiet pinst --disable \
+    && yarn install --immutable
 
 COPY . .
 RUN yarn build


### PR DESCRIPTION
### Type of Change:

Dockerfile の修正

### Details of implementation (実施内容)

Docker イメージのビルド時に husky が見つからないエラーが発生してしまうので, CI での `husky install` のスクリプトを [`pinst`](https://www.npmjs.com/package/pinst) で無効化するようにしました.
