### PR TITLE
ci: semver type を回避

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -27,11 +27,11 @@ runs:
         images: |
           ghcr.io/approvers/oreorebot2
         tags: |
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
+          v${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}
+          v${{ inputs.major }}.${{ inputs.minor }}
+          v${{ inputs.major }}
+          ${{ inputs.sha }}
           type=raw,value=latest,enable={{is_default_branch}}
-          type=sha,format=long,prefix=
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
### Type of Change:

CI の修正

### Cause of the Problem (問題の原因)

[`semver` type のドキュメント](https://github.com/docker/metadata-action#typesemver) によると, これは Git のタグの push イベントでしか使用できませんでした.

### Details of implementation (実施内容)

以前のように入力を介したタグの設定に差し戻しました.
