### PR TITLE
build: Dockerfile の修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
-node_modules
+.yarn/
+!.yarn/releases/
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY . .
 RUN yarn build
 
 WORKDIR /build
-RUN cp -r /src/{build,assets,package.json,yarn.lock} .
+RUN cp -r /src/{build,assets,package.json,yarn.lock,node_modules} .
 
 FROM ubuntu:jammy-20221130
 COPY --from=build /usr/local/include/ /usr/local/include/


### PR DESCRIPTION
Close #722.

### Type of Change:

Dockerfile の修正

### Details of implementation (実施内容)

以前の修正で `node_modules` がコピーされなくなっていたので修正しました. また, `.dockerignore` に `.yarn` の部分を追記しました.
