### PR TITLE
fix: 空の編集イベントに反応しないように修正

### DIFF
--- a/src/service/difference-detector.test.ts
+++ b/src/service/difference-detector.test.ts
@@ -116,3 +116,21 @@ wow`,
 
   expect(fn).not.toHaveBeenCalled();
 });
+
+it('not react to unedited message', async () => {
+  const responder = new DifferenceDetector();
+  const fn = vi.fn(() => Promise.resolve());
+
+  await responder.on(
+    'UPDATE',
+    {
+      content: '草',
+      sendEphemeralToSameChannel: fn
+    },
+    {
+      content: '草',
+      sendEphemeralToSameChannel: fn
+    }
+  );
+  expect(fn).not.toHaveBeenCalled();
+});

--- a/src/service/difference-detector.ts
+++ b/src/service/difference-detector.ts
@@ -62,7 +62,7 @@ export class DifferenceDetector
     after: EditingObservable
   ): Promise<void> {
     const composed = diffComposer(before.content, after.content);
-    if (composed === '') {
+    if (composed === before.content) {
       return;
     }
     await after.sendEphemeralToSameChannel(


### PR DESCRIPTION
### Type of Change:

コードの修正, テストの追加

### Cause of the Problem (問題の原因)

以前に編集差分の検知機能を改善した際に, 差分が検知できない場合の文字列の状況が変わっていました.

### Details of implementation (実施内容)

生成した差分文字列が編集前と同じならば, メッセージを送信しないように修正しました.
