### PR TITLE
fix: sendEphemeralToSameChannel でのメンションを抑制

### DIFF
--- a/src/adaptor/proxy/middleware/message-convert.ts
+++ b/src/adaptor/proxy/middleware/message-convert.ts
@@ -28,7 +28,12 @@ const observableMessage = (
   content: raw.content || '',
   async sendEphemeralToSameChannel(message: string): Promise<void> {
     const FIVE_SECONDS_MS = 5000;
-    const sent = await raw.channel.send(message);
+    const sent = await raw.channel.send({
+      content: message,
+      allowedMentions: {
+        parse: []
+      }
+    });
 
     void sent
       .awaitReactions({


### PR DESCRIPTION
### Type of Change:

コードの改善

### Details of implementation (実施内容)

一時的にしか表示されないメッセージを送信する `sendEphemeralToSameChannel` メソッドでユーザーにメンションが入るのは不自然なので, 該当する文字列があってもメンションされないように `allowedMentions` を指定しました.
