### PR TITLE
feat: 共同通信の記者MEME の追加

### DIFF
--- a/src/service/command/meme/failure.ts
+++ b/src/service/command/meme/failure.ts
@@ -1,0 +1,12 @@
+import type { MemeTemplate } from '../../../model/meme-template.js';
+
+export const failure: MemeTemplate<never, never> = {
+  commandNames: ['failure', 'fail'],
+  description: 'それは一般に失敗と言います、ありがとうございます',
+  flagsKeys: [],
+  optionsKeys: [],
+  errorMessage: 'それは一般に引数エラーと言います、ありがとうございます',
+  generate(args) {
+    return `「${args.body}」\n「それは一般に失敗と言います、ありがとうございます」`;
+  }
+};

--- a/src/service/command/meme/failure.ts
+++ b/src/service/command/meme/failure.ts
@@ -1,12 +1,15 @@
 import type { MemeTemplate } from '../../../model/meme-template.js';
 
+const sourceLink = 'https://dic.nicovideo.jp/id/5671528';
+
 export const failure: MemeTemplate<never, never> = {
   commandNames: ['failure', 'fail'],
-  description: 'それは一般に失敗と言います、ありがとうございます',
+  description: `「〜〜〜」\n「わかりました。それは一般に失敗と言います、ありがとうございます」\n[元ネタ](${sourceLink})'`,
   flagsKeys: [],
   optionsKeys: [],
-  errorMessage: 'それは一般に引数エラーと言います、ありがとうございます',
+  errorMessage:
+    '「わかりました。それは一般に引数エラーと言います、ありがとうございます」',
   generate(args) {
-    return `「${args.body}」\n「それは一般に失敗と言います、ありがとうございます」`;
+    return `「${args.body}」\n「わかりました。それは一般に失敗と言います、ありがとうございます」`;
   }
 };

--- a/src/service/command/meme/index.ts
+++ b/src/service/command/meme/index.ts
@@ -1,5 +1,6 @@
 import { clang } from './clang.js';
 import { dousurya } from './dousurya.js';
+import { failure } from './failure.js';
 import { hukueki } from './hukueki.js';
 import { kenjou } from './kenjou.js';
 import { koume } from './koume.js';
@@ -29,5 +30,6 @@ export const memes = [
   nine,
   tsureteike,
   syakai,
-  clang
+  clang,
+  failure
 ];

--- a/src/service/command/meme/test/failure.test.ts
+++ b/src/service/command/meme/test/failure.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseStringsOrThrow } from '../../../../adaptor/proxy/command/schema.js';
+import { createMockMessage } from '../../command-message.js';
+import { Meme } from '../../meme.js';
+
+describe('meme', () => {
+  const responder = new Meme();
+
+  it('use case of failure', async () => {
+    await responder.on(
+      createMockMessage(
+        parseStringsOrThrow(
+          ['failure', '想定している範囲内で止まることは、失敗と言い難い'],
+          responder.schema
+        ),
+        (message) => {
+          expect(message).toStrictEqual({
+            description:
+              '「想定している範囲内で止まることは、失敗と言い難い」\n「わかりました。それは一般に失敗と言います、ありがとうございます」'
+          });
+        }
+      )
+    );
+  });
+
+  it('args null (failure)', async () => {
+    await responder.on(
+      createMockMessage(
+        parseStringsOrThrow(['failure'], responder.schema),
+        (message) => {
+          expect(message).toStrictEqual({
+            title: '引数が不足してるみたいだ。',
+            description:
+              '「わかりました。それは一般に引数エラーと言います、ありがとうございます」'
+          });
+        }
+      )
+    );
+  });
+});


### PR DESCRIPTION
### Type of Change:

新規追加 (MEME)

### Details of implementation (実施内容)

@KisaragiEffective が提案した MEME を追加します。ちゃんと草は彼にあげます。(いつもの)

```
!failure 想定している範囲内で止まることは、失敗と言い難い

「想定している範囲内で止まることは、失敗と言い難い」
「わかりました。それは一般に失敗と言います、ありがとうございます」
```
