### PR TITLE
feat: 共同通信記者の発言の "失敗" の部分を変えられるオプションを追加

### DIFF
--- a/src/service/command/meme/failure.ts
+++ b/src/service/command/meme/failure.ts
@@ -4,7 +4,7 @@ const sourceLink = 'https://dic.nicovideo.jp/id/5671528';
 
 export const failure: MemeTemplate<never, never> = {
   commandNames: ['failure', 'fail'],
-  description: `「〜〜〜」\n「わかりました。それは一般に失敗と言います、ありがとうございます」\n[元ネタ](${sourceLink})'`,
+  description: `「〜〜〜」\n「わかりました。それは一般に失敗と言います、ありがとうございます」\n[元ネタ](${sourceLink})`,
   flagsKeys: [],
   optionsKeys: [],
   errorMessage:

--- a/src/service/command/meme/failure.ts
+++ b/src/service/command/meme/failure.ts
@@ -2,14 +2,20 @@ import type { MemeTemplate } from '../../../model/meme-template.js';
 
 const sourceLink = 'https://dic.nicovideo.jp/id/5671528';
 
-export const failure: MemeTemplate<never, never> = {
+const failureOption = ['k'] as const;
+
+export const failure: MemeTemplate<never, (typeof failureOption)[number]> = {
   commandNames: ['failure', 'fail'],
   description: `「〜〜〜」\n「わかりました。それは一般に失敗と言います、ありがとうございます」\n[元ネタ](${sourceLink})`,
   flagsKeys: [],
-  optionsKeys: [],
+  optionsKeys: failureOption,
   errorMessage:
     '「わかりました。それは一般に引数エラーと言います、ありがとうございます」',
   generate(args) {
-    return `「${args.body}」\n「わかりました。それは一般に失敗と言います、ありがとうございます」`;
+    const failureArgs = {
+      explanation: args.body,
+      impoliteness: args.options.k ?? '失敗'
+    };
+    return `「${failureArgs.explanation}」\n「わかりました。それは一般に${failureArgs.impoliteness}と言います、ありがとうございます」`;
   }
 };

--- a/src/service/command/meme/failure.ts
+++ b/src/service/command/meme/failure.ts
@@ -6,7 +6,7 @@ const failureOption = ['k'] as const;
 
 export const failure: MemeTemplate<never, (typeof failureOption)[number]> = {
   commandNames: ['failure', 'fail'],
-  description: `「〜〜〜」\n「わかりました。それは一般に失敗と言います、ありがとうございます」\n[元ネタ](${sourceLink})`,
+  description: `「〜〜〜」\n「わかりました。それは一般に失敗と言います、ありがとうございます」\n* \`-k <失敗部分> <説明>\` で失敗部分を変更できます。 \n [元ネタ](${sourceLink})`,
   flagsKeys: [],
   optionsKeys: failureOption,
   errorMessage:

--- a/src/service/command/meme/test/failure.test.ts
+++ b/src/service/command/meme/test/failure.test.ts
@@ -24,6 +24,28 @@ describe('meme', () => {
     );
   });
 
+  it('use case of failure with option -k', async () => {
+    await responder.on(
+      createMockMessage(
+        parseStringsOrThrow(
+          [
+            'failure',
+            '-k',
+            '恋',
+            'クラスのマドンナが好きなのにいじめてしまいました'
+          ],
+          responder.schema
+        ),
+        (message) => {
+          expect(message).toStrictEqual({
+            description:
+              '「クラスのマドンナが好きなのにいじめてしまいました」\n「わかりました。それは一般に恋と言います、ありがとうございます」'
+          });
+        }
+      )
+    );
+  });
+
   it('args null (failure)', async () => {
     await responder.on(
       createMockMessage(


### PR DESCRIPTION
### Type of Change:

新規追加(MEME Option)

### Details of implementation (実施内容)

共同通信記者の失礼発言に含まれる **"失敗"** の部分を自由に変更できるオプション `-k` を追加します。

なお、オプションを含めない場合は通常の失礼発言になります。

```
!fail -k クラスのマドンナが好きなのにいじめてしまいました。 恋

「クラスのマドンナが好きなのにいじめてしまいました。」
「わかりました。それは一般に恋と言います、ありがとうございます」
```
