### PR TITLE
feat: ヘルプ埋め込みからドキュメントサイトのリファレンスに飛べるように

### DIFF
--- a/src/model/meme-template.ts
+++ b/src/model/meme-template.ts
@@ -18,6 +18,11 @@ export interface MemeTemplate<
 > {
   commandNames: readonly string[];
   description: string;
+  /**
+   * はらちょドキュメントサイト(haracho.approvers.dev):
+   * 各ミームリファレンスのページ名を指定する。
+   */
+  docId: string;
   flagsKeys?: readonly FLAGS_KEY[];
   optionsKeys?: readonly OPTIONS_KEY[];
   requiredPositionalKeys?: readonly REQ_POSITIONAL_KEY[];

--- a/src/model/meme-template.ts
+++ b/src/model/meme-template.ts
@@ -22,7 +22,7 @@ export interface MemeTemplate<
    * はらちょドキュメントサイト(haracho.approvers.dev):
    * 各ミームリファレンスのページ名を指定する。
    */
-  docId: string;
+  pageName: string;
   flagsKeys?: readonly FLAGS_KEY[];
   optionsKeys?: readonly OPTIONS_KEY[];
   requiredPositionalKeys?: readonly REQ_POSITIONAL_KEY[];

--- a/src/service/command/channel-info.ts
+++ b/src/service/command/channel-info.ts
@@ -25,7 +25,8 @@ const SCHEMA = {
 export class ChannelInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'チャンネル秘書艦',
-    description: '指定したチャンネルの情報を調べてくるよ'
+    description: '指定したチャンネルの情報を調べてくるよ',
+    docId: 'channelinfo'
   };
 
   readonly schema = SCHEMA;

--- a/src/service/command/channel-info.ts
+++ b/src/service/command/channel-info.ts
@@ -26,7 +26,7 @@ export class ChannelInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'チャンネル秘書艦',
     description: '指定したチャンネルの情報を調べてくるよ',
-    docId: 'channelinfo'
+    docId: 'channel-info'
   };
 
   readonly schema = SCHEMA;

--- a/src/service/command/channel-info.ts
+++ b/src/service/command/channel-info.ts
@@ -26,7 +26,7 @@ export class ChannelInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'チャンネル秘書艦',
     description: '指定したチャンネルの情報を調べてくるよ',
-    docId: 'channel-info'
+    pageName: 'channel-info'
   };
 
   readonly schema = SCHEMA;

--- a/src/service/command/command-message.ts
+++ b/src/service/command/command-message.ts
@@ -85,7 +85,7 @@ export interface HelpInfo {
    * 各コマンドリファレンスのページ名を指定する。
    * 例: !ping コマンドのリファレンスが `haracho.approvers.dev/commands/ping` にある場合は `ping` を docId に指定する。
    */
-  docId: string;
+  pageName: string;
 }
 
 export interface CommandResponder<S extends Schema> {

--- a/src/service/command/command-message.ts
+++ b/src/service/command/command-message.ts
@@ -80,6 +80,12 @@ export interface SentMessage {
 export interface HelpInfo {
   title: string;
   description: string;
+  /**
+   * はらちょドキュメントサイト(haracho.approvers.dev):
+   * 各コマンドリファレンスのページ名を指定する。
+   * 例: !ping コマンドのリファレンスが `haracho.approvers.dev/commands/ping` にある場合は `ping` を docId に指定する。
+   */
+  docId: string;
 }
 
 export interface CommandResponder<S extends Schema> {

--- a/src/service/command/debug.ts
+++ b/src/service/command/debug.ts
@@ -30,7 +30,8 @@ export class DebugCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'デバッガーはらちょ',
     description:
-      'メッセージIDを渡すと、同じチャンネル内にあればそれをコードブロックとして表示するよ'
+      'メッセージIDを渡すと、同じチャンネル内にあればそれをコードブロックとして表示するよ',
+    docId: 'debug'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/debug.ts
+++ b/src/service/command/debug.ts
@@ -31,7 +31,7 @@ export class DebugCommand implements CommandResponder<typeof SCHEMA> {
     title: 'デバッガーはらちょ',
     description:
       'メッセージIDを渡すと、同じチャンネル内にあればそれをコードブロックとして表示するよ',
-    docId: 'debug'
+    pageName: 'debug'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/dice.ts
+++ b/src/service/command/dice.ts
@@ -52,7 +52,7 @@ export class DiceCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ダイスロール',
     description: '賽子が振れるみたいだよ',
-    docId: 'dice'
+    pageName: 'dice'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/dice.ts
+++ b/src/service/command/dice.ts
@@ -51,7 +51,8 @@ const SCHEMA = {
 export class DiceCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ダイスロール',
-    description: '賽子が振れるみたいだよ'
+    description: '賽子が振れるみたいだよ',
+    docId: 'dice'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/guild-info.ts
+++ b/src/service/command/guild-info.ts
@@ -77,7 +77,7 @@ export class GuildInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ギルド秘書艦',
     description: '限界開発鯖の情報を持ってくるよ',
-    docId: 'guildinfo'
+    docId: 'guild-info'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/guild-info.ts
+++ b/src/service/command/guild-info.ts
@@ -76,7 +76,8 @@ const SCHEMA = {
 export class GuildInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ギルド秘書艦',
-    description: '限界開発鯖の情報を持ってくるよ'
+    description: '限界開発鯖の情報を持ってくるよ',
+    docId: 'guildinfo'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/guild-info.ts
+++ b/src/service/command/guild-info.ts
@@ -77,7 +77,7 @@ export class GuildInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ギルド秘書艦',
     description: '限界開発鯖の情報を持ってくるよ',
-    docId: 'guild-info'
+    pageName: 'guild-info'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/gyokuon.ts
+++ b/src/service/command/gyokuon.ts
@@ -24,7 +24,7 @@ export class GyokuonCommand implements CommandResponder<typeof SCHEMA> {
     description:
       'VC内にこるくの玉音放送を再生するよ。引数無しで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ。',
     // 音声機能関連の機能は voice/ 以下にドキュメントを置いているため
-    docId: 'voice/colk'
+    pageName: 'voice/colk'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/gyokuon.ts
+++ b/src/service/command/gyokuon.ts
@@ -23,7 +23,8 @@ export class GyokuonCommand implements CommandResponder<typeof SCHEMA> {
     title: 'こるくの玉音放送',
     description:
       'VC内にこるくの玉音放送を再生するよ。引数無しで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ。',
-    docId: 'gyokuon'
+    // 音声機能関連の機能は voice/ 以下にドキュメントを置いているため
+    docId: 'voice/colk'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/gyokuon.ts
+++ b/src/service/command/gyokuon.ts
@@ -22,7 +22,8 @@ export class GyokuonCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'こるくの玉音放送',
     description:
-      'VC内にこるくの玉音放送を再生するよ。引数無しで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ。'
+      'VC内にこるくの玉音放送を再生するよ。引数無しで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ。',
+    docId: 'gyokuon'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/help.ts
+++ b/src/service/command/help.ts
@@ -36,6 +36,7 @@ export class HelpCommand implements CommandResponder<typeof SCHEMA> {
   private buildField({
     title,
     description,
+    docId,
     names,
     params
   }: Readonly<HelpInfo & Schema>): EmbedPage {
@@ -52,6 +53,7 @@ export class HelpCommand implements CommandResponder<typeof SCHEMA> {
     const patterns = patternsWithDesc.map(([pattern]) => pattern);
     return {
       title,
+      url: `https://haracho.approvers.dev/commands/${docId}`,
       description: `${description}
 \`${names.join('/')}${['', ...patterns].join(' ')}\`
 ${argsDescriptions}`

--- a/src/service/command/help.ts
+++ b/src/service/command/help.ts
@@ -15,7 +15,8 @@ const SCHEMA = {
 export class HelpCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'はらちょヘルプ',
-    description: 'こんな機能が搭載されてるよ'
+    description: 'こんな機能が搭載されてるよ',
+    docId: 'help'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/help.ts
+++ b/src/service/command/help.ts
@@ -16,7 +16,7 @@ export class HelpCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'はらちょヘルプ',
     description: 'こんな機能が搭載されてるよ',
-    docId: 'help'
+    pageName: 'help'
   };
   readonly schema = SCHEMA;
 
@@ -37,7 +37,7 @@ export class HelpCommand implements CommandResponder<typeof SCHEMA> {
   private buildField({
     title,
     description,
-    docId,
+    pageName,
     names,
     params
   }: Readonly<HelpInfo & Schema>): EmbedPage {
@@ -54,7 +54,7 @@ export class HelpCommand implements CommandResponder<typeof SCHEMA> {
     const patterns = patternsWithDesc.map(([pattern]) => pattern);
     return {
       title,
-      url: `https://haracho.approvers.dev/references/commands/${docId}`,
+      url: `https://haracho.approvers.dev/references/commands/${pageName}`,
       description: `${description}
 \`${names.join('/')}${['', ...patterns].join(' ')}\`
 ${argsDescriptions}`

--- a/src/service/command/help.ts
+++ b/src/service/command/help.ts
@@ -54,7 +54,7 @@ export class HelpCommand implements CommandResponder<typeof SCHEMA> {
     const patterns = patternsWithDesc.map(([pattern]) => pattern);
     return {
       title,
-      url: `https://haracho.approvers.dev/commands/${docId}`,
+      url: `https://haracho.approvers.dev/references/commands/${docId}`,
       description: `${description}
 \`${names.join('/')}${['', ...patterns].join(' ')}\`
 ${argsDescriptions}`

--- a/src/service/command/judging.ts
+++ b/src/service/command/judging.ts
@@ -66,7 +66,8 @@ const SCHEMA = {
 export class JudgingCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: JUDGING_TITLE,
-    description: 'プログラムが適格かどうか判定してあげるよ'
+    description: 'プログラムが適格かどうか判定してあげるよ',
+    docId: 'judge'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/judging.ts
+++ b/src/service/command/judging.ts
@@ -67,7 +67,7 @@ export class JudgingCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: JUDGING_TITLE,
     description: 'プログラムが適格かどうか判定してあげるよ',
-    docId: 'judge'
+    pageName: 'judge'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/kaere.ts
+++ b/src/service/command/kaere.ts
@@ -122,7 +122,8 @@ export class KaereCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'Kaere一葉',
     description:
-      'VC内の人類に就寝を促すよ。引数なしで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ'
+      'VC内の人類に就寝を促すよ。引数なしで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ',
+    docId: 'kaere'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/kaere.ts
+++ b/src/service/command/kaere.ts
@@ -124,7 +124,7 @@ export class KaereCommand implements CommandResponder<typeof SCHEMA> {
     description:
       'VC内の人類に就寝を促すよ。引数なしで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ',
     // 音声機能関連の機能は voice/ 以下にドキュメントを置いているため
-    docId: 'voice/kaere'
+    pageName: 'voice/kaere'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/kaere.ts
+++ b/src/service/command/kaere.ts
@@ -123,7 +123,8 @@ export class KaereCommand implements CommandResponder<typeof SCHEMA> {
     title: 'Kaere一葉',
     description:
       'VC内の人類に就寝を促すよ。引数なしで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ',
-    docId: 'kaere'
+    // 音声機能関連の機能は voice/ 以下にドキュメントを置いているため
+    docId: 'voice/kaere'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/kokusei-chousa.ts
+++ b/src/service/command/kokusei-chousa.ts
@@ -24,7 +24,8 @@ const SCHEMA = {
 export class KokuseiChousa implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: '国勢調査',
-    description: '限界開発鯖の人類の数、Botの数とBot率を算出するよ。'
+    description: '限界開発鯖の人類の数、Botの数とBot率を算出するよ。',
+    docId: 'kokusei'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/kokusei-chousa.ts
+++ b/src/service/command/kokusei-chousa.ts
@@ -25,7 +25,7 @@ export class KokuseiChousa implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: '国勢調査',
     description: '限界開発鯖の人類の数、Botの数とBot率を算出するよ。',
-    docId: 'kokusei'
+    pageName: 'kokusei'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/meme.ts
+++ b/src/service/command/meme.ts
@@ -33,7 +33,7 @@ export class Meme implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ミーム構文機能',
     description: '何これ……引数のテキストを構文にはめ込むみたいだよ',
-    docId: 'meme'
+    pageName: 'meme'
   };
   readonly schema = SCHEMA;
 
@@ -88,7 +88,7 @@ export class Meme implements CommandResponder<typeof SCHEMA> {
     if (argv.help) {
       await message.reply({
         title: meme.commandNames.map((name) => `\`${name}\``).join('/'),
-        url: `https://haracho.approvers.dev/references/commands/meme/${meme.docId}`,
+        url: `https://haracho.approvers.dev/references/commands/meme/${meme.pageName}`,
         description: meme.description
       });
       return;

--- a/src/service/command/meme.ts
+++ b/src/service/command/meme.ts
@@ -32,7 +32,8 @@ const SCHEMA = {
 export class Meme implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ミーム構文機能',
-    description: '何これ……引数のテキストを構文にはめ込むみたいだよ'
+    description: '何これ……引数のテキストを構文にはめ込むみたいだよ',
+    docId: 'meme'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/meme.ts
+++ b/src/service/command/meme.ts
@@ -88,6 +88,7 @@ export class Meme implements CommandResponder<typeof SCHEMA> {
     if (argv.help) {
       await message.reply({
         title: meme.commandNames.map((name) => `\`${name}\``).join('/'),
+        url: `https://haracho.approvers.dev/commands/meme/${meme.docId}`,
         description: meme.description
       });
       return;

--- a/src/service/command/meme.ts
+++ b/src/service/command/meme.ts
@@ -88,7 +88,7 @@ export class Meme implements CommandResponder<typeof SCHEMA> {
     if (argv.help) {
       await message.reply({
         title: meme.commandNames.map((name) => `\`${name}\``).join('/'),
-        url: `https://haracho.approvers.dev/commands/meme/${meme.docId}`,
+        url: `https://haracho.approvers.dev/references/commands/meme/${meme.docId}`,
         description: meme.description
       });
       return;

--- a/src/service/command/meme/clang.ts
+++ b/src/service/command/meme/clang.ts
@@ -9,6 +9,7 @@ export const clang: MemeTemplate<
 > = {
   commandNames: ['clang', 'c'],
   description: '〜の天才\n9つの〜を操る',
+  docId: 'clang',
   requiredPositionalKeys: positionalKeys,
   errorMessage: 'エラーの天才\n9つの引数エラーを操る',
   generate({ requiredPositionals: { domain, way } }) {

--- a/src/service/command/meme/clang.ts
+++ b/src/service/command/meme/clang.ts
@@ -9,7 +9,7 @@ export const clang: MemeTemplate<
 > = {
   commandNames: ['clang', 'c'],
   description: '〜の天才\n9つの〜を操る',
-  docId: 'clang',
+  pageName: 'clang',
   requiredPositionalKeys: positionalKeys,
   errorMessage: 'エラーの天才\n9つの引数エラーを操る',
   generate({ requiredPositionals: { domain, way } }) {

--- a/src/service/command/meme/dousurya.ts
+++ b/src/service/command/meme/dousurya.ts
@@ -9,7 +9,7 @@ export const dousurya: MemeTemplate<
 > = {
   commandNames: ['dousurya', 'dousureba'],
   description: '限界みたいな鯖に住んでる〜はどうすりゃいいですか？',
-  docId: 'dousurya',
+  pageName: 'dousurya',
   requiredPositionalKeys: positionalKeys,
   errorMessage: 'どうしようもない。',
   generate(args) {

--- a/src/service/command/meme/dousurya.ts
+++ b/src/service/command/meme/dousurya.ts
@@ -9,6 +9,7 @@ export const dousurya: MemeTemplate<
 > = {
   commandNames: ['dousurya', 'dousureba'],
   description: '限界みたいな鯖に住んでる〜はどうすりゃいいですか？',
+  docId: 'dousurya',
   requiredPositionalKeys: positionalKeys,
   errorMessage: 'どうしようもない。',
   generate(args) {

--- a/src/service/command/meme/failure.ts
+++ b/src/service/command/meme/failure.ts
@@ -12,6 +12,7 @@ export const failure: MemeTemplate<
 > = {
   commandNames: ['failure', 'fail'],
   description: `「〜〜〜」\n「わかりました。それは一般に失敗と言います、ありがとうございます」\n* \`-k <失敗部分> <説明>\` で失敗部分を変更できます。 \n [元ネタ](${sourceLink})`,
+  docId: 'failure',
   optionsKeys: failureOption,
   requiredPositionalKeys: positionalKeys,
   errorMessage:

--- a/src/service/command/meme/failure.ts
+++ b/src/service/command/meme/failure.ts
@@ -12,7 +12,7 @@ export const failure: MemeTemplate<
 > = {
   commandNames: ['failure', 'fail'],
   description: `「〜〜〜」\n「わかりました。それは一般に失敗と言います、ありがとうございます」\n* \`-k <失敗部分> <説明>\` で失敗部分を変更できます。 \n [元ネタ](${sourceLink})`,
-  docId: 'failure',
+  pageName: 'failure',
   optionsKeys: failureOption,
   requiredPositionalKeys: positionalKeys,
   errorMessage:

--- a/src/service/command/meme/hukueki.ts
+++ b/src/service/command/meme/hukueki.ts
@@ -9,7 +9,7 @@ export const hukueki: MemeTemplate<
 > = {
   commandNames: ['hukueki'],
   description: 'ねぇ、将来何してるだろうね\n〜はしてないといいね\n困らないでよ',
-  docId: 'hukueki',
+  pageName: 'hukueki',
   requiredPositionalKeys: positionalKeys,
   errorMessage: '服役できなかった。',
   generate(args) {

--- a/src/service/command/meme/hukueki.ts
+++ b/src/service/command/meme/hukueki.ts
@@ -9,6 +9,7 @@ export const hukueki: MemeTemplate<
 > = {
   commandNames: ['hukueki'],
   description: 'ねぇ、将来何してるだろうね\n〜はしてないといいね\n困らないでよ',
+  docId: 'hukueki',
   requiredPositionalKeys: positionalKeys,
   errorMessage: '服役できなかった。',
   generate(args) {

--- a/src/service/command/meme/kenjou.ts
+++ b/src/service/command/meme/kenjou.ts
@@ -10,7 +10,7 @@ export const kenjou: MemeTemplate<
   commandNames: ['kenjou'],
   description:
     '[健常者エミュレーター](https://healthy-person-emulator.memo.wiki/)の構文ジェネレーター。\n健常者エミュレーターWikiにありそうなタイトルを指定すればうまくいきます。',
-  docId: 'kenjou',
+  pageName: 'kenjou',
   requiredPositionalKeys: positionalKeys,
   errorMessage:
     'はらちょのミーム機能を使うときは引数を忘れない方がいい - 健常者エミュレータ事例集Wiki',

--- a/src/service/command/meme/kenjou.ts
+++ b/src/service/command/meme/kenjou.ts
@@ -10,6 +10,7 @@ export const kenjou: MemeTemplate<
   commandNames: ['kenjou'],
   description:
     '[健常者エミュレーター](https://healthy-person-emulator.memo.wiki/)の構文ジェネレーター。\n健常者エミュレーターWikiにありそうなタイトルを指定すればうまくいきます。',
+  docId: 'kenjou',
   requiredPositionalKeys: positionalKeys,
   errorMessage:
     'はらちょのミーム機能を使うときは引数を忘れない方がいい - 健常者エミュレータ事例集Wiki',

--- a/src/service/command/meme/koume.ts
+++ b/src/service/command/meme/koume.ts
@@ -9,7 +9,7 @@ export const koume: MemeTemplate<
 > = {
   commandNames: ['koume'],
   description: '〜と思ったら〜♪\n\n〜でした〜♪\n\n引数は2つ必要です。',
-  docId: 'koume',
+  pageName: 'koume',
   requiredPositionalKeys: positionalKeys,
   errorMessage:
     'MEMEを表示しようと思ったら〜♪ 引数が足りませんでした〜♪ チクショー！！',

--- a/src/service/command/meme/koume.ts
+++ b/src/service/command/meme/koume.ts
@@ -9,6 +9,7 @@ export const koume: MemeTemplate<
 > = {
   commandNames: ['koume'],
   description: '〜と思ったら〜♪\n\n〜でした〜♪\n\n引数は2つ必要です。',
+  docId: 'koume',
   requiredPositionalKeys: positionalKeys,
   errorMessage:
     'MEMEを表示しようと思ったら〜♪ 引数が足りませんでした〜♪ チクショー！！',

--- a/src/service/command/meme/lolicon.ts
+++ b/src/service/command/meme/lolicon.ts
@@ -9,6 +9,7 @@ export const lolicon: MemeTemplate<
 > = {
   commandNames: ['lolicon'],
   description: 'だから僕は〜を辞めた',
+  docId: 'lolicon',
   requiredPositionalKeys: positionalKeys,
   errorMessage: 'こるくはロリコンをやめられなかった。',
   generate(args, author) {

--- a/src/service/command/meme/lolicon.ts
+++ b/src/service/command/meme/lolicon.ts
@@ -9,7 +9,7 @@ export const lolicon: MemeTemplate<
 > = {
   commandNames: ['lolicon'],
   description: 'だから僕は〜を辞めた',
-  docId: 'lolicon',
+  pageName: 'lolicon',
   requiredPositionalKeys: positionalKeys,
   errorMessage: 'こるくはロリコンをやめられなかった。',
   generate(args, author) {

--- a/src/service/command/meme/moeta.ts
+++ b/src/service/command/meme/moeta.ts
@@ -12,7 +12,7 @@ export const moeta: MemeTemplate<
 > = {
   commandNames: ['moeta', 'yuki'],
   description: `「久留米の花火大会ね、寮から見れたの?」\n「うん ついでに〜が燃えた」\n${source}`,
-  docId: 'moeta',
+  pageName: 'moeta',
   requiredPositionalKeys: positionalKeys,
   errorMessage: source,
   generate(args) {

--- a/src/service/command/meme/moeta.ts
+++ b/src/service/command/meme/moeta.ts
@@ -12,6 +12,7 @@ export const moeta: MemeTemplate<
 > = {
   commandNames: ['moeta', 'yuki'],
   description: `「久留米の花火大会ね、寮から見れたの?」\n「うん ついでに〜が燃えた」\n${source}`,
+  docId: 'moeta',
   requiredPositionalKeys: positionalKeys,
   errorMessage: source,
   generate(args) {

--- a/src/service/command/meme/n.ts
+++ b/src/service/command/meme/n.ts
@@ -5,7 +5,7 @@ const positionalKeys = ['context'] as const;
 export const n: MemeTemplate<never, never, (typeof positionalKeys)[number]> = {
   commandNames: ['n'],
   description: '〜Nった',
-  docId: 'n',
+  pageName: 'n',
   requiredPositionalKeys: positionalKeys,
   errorMessage: 'このままだと <@521958252280545280> みたいに留年しちゃう....',
   generate(args) {

--- a/src/service/command/meme/n.ts
+++ b/src/service/command/meme/n.ts
@@ -5,6 +5,7 @@ const positionalKeys = ['context'] as const;
 export const n: MemeTemplate<never, never, (typeof positionalKeys)[number]> = {
   commandNames: ['n'],
   description: '〜Nった',
+  docId: 'n',
   requiredPositionalKeys: positionalKeys,
   errorMessage: 'このままだと <@521958252280545280> みたいに留年しちゃう....',
   generate(args) {

--- a/src/service/command/meme/nigetane.ts
+++ b/src/service/command/meme/nigetane.ts
@@ -12,7 +12,7 @@ export const nigetane: MemeTemplate<
 > = {
   commandNames: ['nigetane'],
   description: '… 〜から悪くないって、… (from Arcaea "Final Verdict")',
-  docId: 'nigetane',
+  pageName: 'nigetane',
   requiredPositionalKeys: positionalKeys,
   errorMessage: '……手遅れなのは頭（おつむ）からなのかな。',
   generate: ({ requiredPositionals: { reason } }) => template(reason)

--- a/src/service/command/meme/nigetane.ts
+++ b/src/service/command/meme/nigetane.ts
@@ -12,6 +12,7 @@ export const nigetane: MemeTemplate<
 > = {
   commandNames: ['nigetane'],
   description: '… 〜から悪くないって、… (from Arcaea "Final Verdict")',
+  docId: 'nigetane',
   requiredPositionalKeys: positionalKeys,
   errorMessage: '……手遅れなのは頭（おつむ）からなのかな。',
   generate: ({ requiredPositionals: { reason } }) => template(reason)

--- a/src/service/command/meme/nine.ts
+++ b/src/service/command/meme/nine.ts
@@ -6,7 +6,7 @@ export const nine: MemeTemplate<never, never, (typeof positionalKeys)[number]> =
   {
     commandNames: ['nine'],
     description: '〇〇は〇〇が9割',
-    docId: 'nine',
+    pageName: 'nine',
     requiredPositionalKeys: positionalKeys,
     errorMessage: '人は引数ミスが9割',
     generate({ requiredPositionals: { subject, entity } }) {

--- a/src/service/command/meme/nine.ts
+++ b/src/service/command/meme/nine.ts
@@ -6,6 +6,7 @@ export const nine: MemeTemplate<never, never, (typeof positionalKeys)[number]> =
   {
     commandNames: ['nine'],
     description: '〇〇は〇〇が9割',
+    docId: 'nine',
     requiredPositionalKeys: positionalKeys,
     errorMessage: '人は引数ミスが9割',
     generate({ requiredPositionals: { subject, entity } }) {

--- a/src/service/command/meme/ojaru.ts
+++ b/src/service/command/meme/ojaru.ts
@@ -12,7 +12,7 @@ export const ojaru: MemeTemplate<
   commandNames: ['ojaru'],
   description:
     'あっぱれおじゃる様！見事ミーム構文を使いこなされました！`-g`オプションを使用なさってデンボの口調の変更も可能でございます！',
-  docId: 'ojaru',
+  pageName: 'ojaru',
   flagsKeys: ojaruFlags,
   requiredPositionalKeys: positionalKeys,
   errorMessage:

--- a/src/service/command/meme/ojaru.ts
+++ b/src/service/command/meme/ojaru.ts
@@ -12,6 +12,7 @@ export const ojaru: MemeTemplate<
   commandNames: ['ojaru'],
   description:
     'あっぱれおじゃる様！見事ミーム構文を使いこなされました！`-g`オプションを使用なさってデンボの口調の変更も可能でございます！',
+  docId: 'ojaru',
   flagsKeys: ojaruFlags,
   requiredPositionalKeys: positionalKeys,
   errorMessage:

--- a/src/service/command/meme/syakai.ts
+++ b/src/service/command/meme/syakai.ts
@@ -9,7 +9,7 @@ export const syakai: MemeTemplate<
 > = {
   commandNames: ['syakai'],
   description: '「首相、～に否定的な考え ― 『社会が変わってしまう』」',
-  docId: 'syakai',
+  pageName: 'syakai',
   requiredPositionalKeys: positionalKeys,
   errorMessage: '極めて慎重に検討すべき課題だ',
   generate(args) {

--- a/src/service/command/meme/syakai.ts
+++ b/src/service/command/meme/syakai.ts
@@ -9,6 +9,7 @@ export const syakai: MemeTemplate<
 > = {
   commandNames: ['syakai'],
   description: '「首相、～に否定的な考え ― 『社会が変わってしまう』」',
+  docId: 'syakai',
   requiredPositionalKeys: positionalKeys,
   errorMessage: '極めて慎重に検討すべき課題だ',
   generate(args) {

--- a/src/service/command/meme/takopi.ts
+++ b/src/service/command/meme/takopi.ts
@@ -12,7 +12,7 @@ export const takopi: MemeTemplate<
   commandNames: ['takopi'],
   description:
     '「〜、出して」\n`-f` で教員と自分の名前の位置を反対にします。\n`-c <教員の名前> <出すもの>`で教員の名前も変更可能です。',
-  docId: 'takopi',
+  pageName: 'takopi',
   flagsKeys: takopiFlags,
   optionsKeys: takopiOptions,
   requiredPositionalKeys: positionalKeys,

--- a/src/service/command/meme/takopi.ts
+++ b/src/service/command/meme/takopi.ts
@@ -12,6 +12,7 @@ export const takopi: MemeTemplate<
   commandNames: ['takopi'],
   description:
     '「〜、出して」\n`-f` で教員と自分の名前の位置を反対にします。\n`-c <教員の名前> <出すもの>`で教員の名前も変更可能です。',
+  docId: 'takopi',
   flagsKeys: takopiFlags,
   optionsKeys: takopiOptions,
   requiredPositionalKeys: positionalKeys,

--- a/src/service/command/meme/tsureteike.ts
+++ b/src/service/command/meme/tsureteike.ts
@@ -16,6 +16,7 @@ export const tsureteike: MemeTemplate<
   commandNames: ['tsureteike', 'hunt'],
   description:
     '「この中に〜はいるか 連れて行け」\nex.) `!tsureteike プログラマ Rustは知っているか? ゲームですか? 錆のこと? 🦀`',
+  docId: 'tsureteike',
   requiredPositionalKeys: positionalKeys,
   errorMessage: '構文ミスだ、問答無用で連れて行け',
   generate({ requiredPositionals }) {

--- a/src/service/command/meme/tsureteike.ts
+++ b/src/service/command/meme/tsureteike.ts
@@ -16,7 +16,7 @@ export const tsureteike: MemeTemplate<
   commandNames: ['tsureteike', 'hunt'],
   description:
     '「この中に〜はいるか 連れて行け」\nex.) `!tsureteike プログラマ Rustは知っているか? ゲームですか? 錆のこと? 🦀`',
-  docId: 'tsureteike',
+  pageName: 'tsureteike',
   requiredPositionalKeys: positionalKeys,
   errorMessage: '構文ミスだ、問答無用で連れて行け',
   generate({ requiredPositionals }) {

--- a/src/service/command/meme/web3.ts
+++ b/src/service/command/meme/web3.ts
@@ -6,6 +6,7 @@ export const web3: MemeTemplate<never, never, (typeof positionalKeys)[number]> =
   {
     commandNames: ['web3'],
     description: '「いちばんやさしい〜の教本」',
+    docId: 'web3',
     requiredPositionalKeys: positionalKeys,
     errorMessage: 'TCP/IP、SMTP、HTTPはGoogleやAmazonに独占されています。',
     generate(args) {

--- a/src/service/command/meme/web3.ts
+++ b/src/service/command/meme/web3.ts
@@ -6,7 +6,7 @@ export const web3: MemeTemplate<never, never, (typeof positionalKeys)[number]> =
   {
     commandNames: ['web3'],
     description: '「いちばんやさしい〜の教本」',
-    docId: 'web3',
+    pageName: 'web3',
     requiredPositionalKeys: positionalKeys,
     errorMessage: 'TCP/IP、SMTP、HTTPはGoogleやAmazonに独占されています。',
     generate(args) {

--- a/src/service/command/party.ts
+++ b/src/service/command/party.ts
@@ -96,7 +96,7 @@ export class PartyCommand implements CommandResponder<typeof SCHEMA> {
     description:
       'VC内の人類に押しかけてPartyを開くよ。引数なしで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ',
     // 音声機能関連の機能は voice/ 以下にドキュメントを置いているため
-    docId: 'voice/party'
+    pageName: 'voice/party'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/party.ts
+++ b/src/service/command/party.ts
@@ -94,7 +94,8 @@ export class PartyCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'Party一葉',
     description:
-      'VC内の人類に押しかけてPartyを開くよ。引数なしで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ'
+      'VC内の人類に押しかけてPartyを開くよ。引数なしで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ',
+    docId: 'patry'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/party.ts
+++ b/src/service/command/party.ts
@@ -95,7 +95,8 @@ export class PartyCommand implements CommandResponder<typeof SCHEMA> {
     title: 'Party一葉',
     description:
       'VC内の人類に押しかけてPartyを開くよ。引数なしで即起動。どの方式でもコマンド発行者がVCに居ないと動かないよ',
-    docId: 'patry'
+    // 音声機能関連の機能は voice/ 以下にドキュメントを置いているため
+    docId: 'voice/party'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/ping.ts
+++ b/src/service/command/ping.ts
@@ -19,7 +19,8 @@ const SCHEMA = {
 export class PingCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'Ping',
-    description: '現在のレイテンシを表示するよ。'
+    description: '現在のレイテンシを表示するよ。',
+    docId: 'ping'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/ping.ts
+++ b/src/service/command/ping.ts
@@ -20,7 +20,7 @@ export class PingCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'Ping',
     description: '現在のレイテンシを表示するよ。',
-    docId: 'ping'
+    pageName: 'ping'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-create.ts
+++ b/src/service/command/role-create.ts
@@ -35,7 +35,8 @@ const SCHEMA = {
 export class RoleCreate implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール作成',
-    description: 'ロールを作成するよ'
+    description: 'ロールを作成するよ',
+    docId: 'rolecreate'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-create.ts
+++ b/src/service/command/role-create.ts
@@ -36,7 +36,7 @@ export class RoleCreate implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール作成',
     description: 'ロールを作成するよ',
-    docId: 'rolecreate'
+    docId: 'role-create'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-create.ts
+++ b/src/service/command/role-create.ts
@@ -36,7 +36,7 @@ export class RoleCreate implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール作成',
     description: 'ロールを作成するよ',
-    docId: 'role-create'
+    pageName: 'role-create'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-info.ts
+++ b/src/service/command/role-info.ts
@@ -42,7 +42,8 @@ const SCHEMA = {
 export class RoleInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール秘書艦',
-    description: '指定したロールの情報を調べてくるよ'
+    description: '指定したロールの情報を調べてくるよ',
+    docId: 'roleinfo'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-info.ts
+++ b/src/service/command/role-info.ts
@@ -43,7 +43,7 @@ export class RoleInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール秘書艦',
     description: '指定したロールの情報を調べてくるよ',
-    docId: 'role-info'
+    pageName: 'role-info'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-info.ts
+++ b/src/service/command/role-info.ts
@@ -43,7 +43,7 @@ export class RoleInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール秘書艦',
     description: '指定したロールの情報を調べてくるよ',
-    docId: 'roleinfo'
+    docId: 'role-info'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-rank.ts
+++ b/src/service/command/role-rank.ts
@@ -22,7 +22,7 @@ export class RoleRank implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール数ランキング',
     description: '各メンバーごとのロール数をランキング形式で表示するよ',
-    docId: 'role-rank'
+    pageName: 'role-rank'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-rank.ts
+++ b/src/service/command/role-rank.ts
@@ -22,7 +22,7 @@ export class RoleRank implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール数ランキング',
     description: '各メンバーごとのロール数をランキング形式で表示するよ',
-    docId: 'rolerank'
+    docId: 'role-rank'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/role-rank.ts
+++ b/src/service/command/role-rank.ts
@@ -21,7 +21,8 @@ const SCHEMA = {
 export class RoleRank implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ロール数ランキング',
-    description: '各メンバーごとのロール数をランキング形式で表示するよ'
+    description: '各メンバーごとのロール数をランキング形式で表示するよ',
+    docId: 'rolerank'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/stfu.ts
+++ b/src/service/command/stfu.ts
@@ -41,7 +41,8 @@ export class SheriffCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: '治安統率機構',
     description:
-      'はらちょがうるさいときに治安維持するためのコマンドだよ。最新メッセージから 50 件以内のはらちょのメッセージを指定の個数だけ削除するよ。'
+      'はらちょがうるさいときに治安維持するためのコマンドだよ。最新メッセージから 50 件以内のはらちょのメッセージを指定の個数だけ削除するよ。',
+    docId: 'stfu'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/stfu.ts
+++ b/src/service/command/stfu.ts
@@ -42,7 +42,7 @@ export class SheriffCommand implements CommandResponder<typeof SCHEMA> {
     title: '治安統率機構',
     description:
       'はらちょがうるさいときに治安維持するためのコマンドだよ。最新メッセージから 50 件以内のはらちょのメッセージを指定の個数だけ削除するよ。',
-    docId: 'stfu'
+    pageName: 'stfu'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/typo-record.ts
+++ b/src/service/command/typo-record.ts
@@ -117,7 +117,8 @@ const SCHEMA = {
 export class TypoReporter implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: '今日のTypo',
-    description: '「〜だカス」をTypoとして一日間記録するよ'
+    description: '「〜だカス」をTypoとして一日間記録するよ',
+    docId: 'typo'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/typo-record.ts
+++ b/src/service/command/typo-record.ts
@@ -118,7 +118,7 @@ export class TypoReporter implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: '今日のTypo',
     description: '「〜だカス」をTypoとして一日間記録するよ',
-    docId: 'typo'
+    pageName: 'typo'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/user-info.ts
+++ b/src/service/command/user-info.ts
@@ -39,7 +39,7 @@ export class UserInfo implements CommandResponder<typeof SCHEMA> {
     title: 'ユーザー秘書艦',
     description:
       '指定したユーザーの情報を調べてくるよ。限界開発鯖のメンバーしか検索できないから注意してね。',
-    docId: 'userinfo'
+    docId: 'user-info'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/user-info.ts
+++ b/src/service/command/user-info.ts
@@ -38,7 +38,8 @@ export class UserInfo implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'ユーザー秘書艦',
     description:
-      '指定したユーザーの情報を調べてくるよ。限界開発鯖のメンバーしか検索できないから注意してね。'
+      '指定したユーザーの情報を調べてくるよ。限界開発鯖のメンバーしか検索できないから注意してね。',
+    docId: 'userinfo'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/user-info.ts
+++ b/src/service/command/user-info.ts
@@ -39,7 +39,7 @@ export class UserInfo implements CommandResponder<typeof SCHEMA> {
     title: 'ユーザー秘書艦',
     description:
       '指定したユーザーの情報を調べてくるよ。限界開発鯖のメンバーしか検索できないから注意してね。',
-    docId: 'user-info'
+    pageName: 'user-info'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/version.ts
+++ b/src/service/command/version.ts
@@ -16,7 +16,8 @@ const SCHEMA = {
 export class GetVersionCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'はらちょバージョン',
-    description: '現在の私のバージョンを出力するよ。'
+    description: '現在の私のバージョンを出力するよ。',
+    docId: 'version'
   };
   readonly schema = SCHEMA;
 

--- a/src/service/command/version.ts
+++ b/src/service/command/version.ts
@@ -17,7 +17,7 @@ export class GetVersionCommand implements CommandResponder<typeof SCHEMA> {
   help: Readonly<HelpInfo> = {
     title: 'はらちょバージョン',
     description: '現在の私のバージョンを出力するよ。',
-    docId: 'version'
+    pageName: 'version'
   };
   readonly schema = SCHEMA;
 


### PR DESCRIPTION
### Type of Change:

新機能追加(ヘルプ)

### Details of implementation (実施内容)

`!help` コマンドで表示される埋め込みのタイトルから各コマンドリファレンスに飛べるようにします。

----

- [x] Nextra 移行後の新ドキュメントサイトに対応
- [x] すべてのコマンドヘルプでリファレンスに飛べるかどうか確認