### PR TITLE
fix: 健常者エミュレーターWikiのURLを新しいWikiに置き換え

### DIFF
--- a/src/service/command/meme/kenjou.ts
+++ b/src/service/command/meme/kenjou.ts
@@ -1,5 +1,6 @@
 import type { MemeTemplate } from '../../../model/meme-template.js';
 
+const sourceTitle = '健常者エミュレータ事例集';
 const sourceLink = 'https://healthy-person-emulator.org/';
 
 const positionalKeys = ['title'] as const;
@@ -10,12 +11,11 @@ export const kenjou: MemeTemplate<
   (typeof positionalKeys)[number]
 > = {
   commandNames: ['kenjou'],
-  description: `[健常者エミュレーターWiki](${sourceLink})の構文ジェネレーター。\n健常者エミュレーターWikiにありそうなタイトルを指定すればうまくいきます。`,
+  description: `[${sourceTitle}](${sourceLink})の構文ジェネレーター。\n${sourceTitle}にありそうなタイトルを指定すればうまくいきます。`,
   pageName: 'kenjou',
   requiredPositionalKeys: positionalKeys,
-  errorMessage:
-    'はらちょのミーム機能を使うときは引数を忘れない方がいい - 健常者エミュレータ事例集Wiki',
+  errorMessage: `はらちょのミーム機能を使うときは引数を忘れない方がいい - ${sourceTitle}`,
   generate(args) {
-    return `${args.requiredPositionals.title} - 健常者エミュレータ事例集Wiki`;
+    return `${args.requiredPositionals.title} - ${sourceTitle}`;
   }
 };

--- a/src/service/command/meme/kenjou.ts
+++ b/src/service/command/meme/kenjou.ts
@@ -1,5 +1,7 @@
 import type { MemeTemplate } from '../../../model/meme-template.js';
 
+const sourceLink = 'https://healthy-person-emulator.org/';
+
 const positionalKeys = ['title'] as const;
 
 export const kenjou: MemeTemplate<
@@ -8,8 +10,7 @@ export const kenjou: MemeTemplate<
   (typeof positionalKeys)[number]
 > = {
   commandNames: ['kenjou'],
-  description:
-    '[健常者エミュレーター](https://healthy-person-emulator.memo.wiki/)の構文ジェネレーター。\n健常者エミュレーターWikiにありそうなタイトルを指定すればうまくいきます。',
+  description: `[健常者エミュレーターWiki](${sourceLink})の構文ジェネレーター。\n健常者エミュレーターWikiにありそうなタイトルを指定すればうまくいきます。`,
   pageName: 'kenjou',
   requiredPositionalKeys: positionalKeys,
   errorMessage:

--- a/src/service/command/meme/test/kenjou.test.ts
+++ b/src/service/command/meme/test/kenjou.test.ts
@@ -20,7 +20,7 @@ describe('meme', () => {
         (message) => {
           expect(message).toStrictEqual({
             description:
-              'ホテルのオートロックの鍵は部屋に置きっぱなしにしないほうがいい - 健常者エミュレータ事例集Wiki'
+              'ホテルのオートロックの鍵は部屋に置きっぱなしにしないほうがいい - 健常者エミュレータ事例集'
           });
         }
       )
@@ -35,7 +35,7 @@ describe('meme', () => {
           expect(message).toStrictEqual({
             title: '引数が不足してるみたいだ。',
             description:
-              'はらちょのミーム機能を使うときは引数を忘れない方がいい - 健常者エミュレータ事例集Wiki'
+              'はらちょのミーム機能を使うときは引数を忘れない方がいい - 健常者エミュレータ事例集'
           });
         }
       )


### PR DESCRIPTION
close #759 

### Type of Change:

修正

### Details of implementation (実施内容)

`!kenjou --help` で表示される健常者エミュレーターWikiのURLを新しいものに置き換えました。
