### PR TITLE
fix(docs): inconsistency between Security Policy and Contributing Guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ OreOreBot2 の不具合を発見した際は **[Issues](https://github.com/appro
 
 ### セキュリティーに関する不具合の報告
 
-セキュリティーに関する不具合は Issue ではなく、GitHub Security Advisories から Draft Advisory を生成してください。
+セキュリティーに関する不具合は Issue ではなく、[GitHub Security Advisories から Draft Advisory を作成](https://github.com/approvers/OreOreBot2/security/advisories/new)してください。
 
 脆弱性だと判断され次第、Security Advisories に掲載されます。
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,19 +2,21 @@
 
 OreOreBot2 には誰でも貢献でき、その貢献にはさまざまな方法があります。
 
-- [バグレポートの提出](#バグレポートの提出)
-  - [セキュリティーに関する不具合の報告](#セキュリティーに関する不具合の報告)
-- [新機能リクエストの提出](#新機能リクエストの提出)
-- [プルリクエストの提出](#プルリクエストの提出)
-  - [開発参加の流れ](#開発参加の流れ)
-  - [コーティング規約](#コーティング規約)
-  - [テストについて](#テストについて)
-  - [コミットメッセージ](#コミットメッセージ)
-  - [その他](#その他)
-- [GitHub Sponsor の掲載条件](#github-sponsor-の掲載条件)
-- [開発環境](#開発環境)
-  - [機能の有効・無効](#機能の有効無効)
-  - [音楽再生系の機能](#音楽再生系の機能)
+- [OreOreBot2 への貢献](#oreorebot2-への貢献)
+  - [バグレポートの提出](#バグレポートの提出)
+    - [セキュリティーに関する不具合の報告](#セキュリティーに関する不具合の報告)
+  - [新機能リクエストの提出](#新機能リクエストの提出)
+  - [プルリクエストの提出](#プルリクエストの提出)
+    - [開発参加の流れ](#開発参加の流れ)
+    - [コーティング規約](#コーティング規約)
+    - [テストについて](#テストについて)
+      - [テストの例](#テストの例)
+    - [コミットメッセージ](#コミットメッセージ)
+    - [その他](#その他)
+  - [GitHub Sponsor の掲載条件](#github-sponsor-の掲載条件)
+  - [開発環境](#開発環境)
+    - [機能の有効・無効](#機能の有効無効)
+    - [音楽再生系の機能](#音楽再生系の機能)
 
 ## バグレポートの提出
 
@@ -29,20 +31,13 @@ OreOreBot2 の不具合を発見した際は **[Issues](https://github.com/appro
 
 ### セキュリティーに関する不具合の報告
 
-セキュリティーに関する不具合は Issue ではなく、適切な方法で報告する必要があります。
+セキュリティーに関する不具合は Issue ではなく、GitHub Security Advisories から Draft Advisory を生成してください。
 
-報告する方法は 2 つあります。どちらで報告しても構いません。
+脆弱性だと判断され次第、Security Advisories に掲載されます。
 
-1. `me@m2en.dev` 宛に以下の GPG 鍵で署名したメールを送信する
-   鍵指紋: `78E4 CFE0 B3B2 0C4C 7BAA A3CA 6554 A829 D251 53F9` , [pgp_keys.asc](https://keybase.io/m2en/pgp_keys.asc?fingerprint=78e4cfe0b3b20c4c7baaa3ca6554a829d25153f9)
-2. [GitHub Security Advisories](https://github.com/approvers/OreOreBot2/security/advisories/new) からセキュリティ勧告を作成する
+作成方法については GitHub Docs を確認してください。
 
-上記 2 つの方法、どちらとも以下の情報を詳細に記載してください。
-
-- `Impact` - どのような脆弱性で、誰が影響を受けるのか
-- `Process` - 問題を再現するための手段
-- `PoC` - 概念実証。脆弱性を利用した攻撃が可能であることを示す実際のコード (可能であれば)
-- `Version` - 脆弱性が存在するバージョン
+[Creating a repository security advisory - GitHub Docs](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/creating-a-repository-security-advisory)
 
 ## 新機能リクエストの提出
 
@@ -198,8 +193,9 @@ describe('RoleRank', () => {
 
 ```ts
 import { expect, it, vi } from 'vitest';
-import { Meme } from './meme.js';
+
 import { createMockMessage } from './command-message.js';
+import { Meme } from './meme.js';
 
 it('use case of hukueki', async () => {
   const fn = vi.fn();

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,13 +31,7 @@ OreOreBot2 の不具合を発見した際は **[Issues](https://github.com/appro
 
 ### セキュリティーに関する不具合の報告
 
-セキュリティーに関する不具合は Issue ではなく、[GitHub Security Advisories から Draft Advisory を作成](https://github.com/approvers/OreOreBot2/security/advisories/new)してください。
-
-脆弱性だと判断され次第、Security Advisories に掲載されます。
-
-作成方法については GitHub Docs を確認してください。
-
-[Creating a repository security advisory - GitHub Docs](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/creating-a-repository-security-advisory)
+[OreOreBot2 Security Policy](../SECURITY.md) を確認してください。
 
 ## 新機能リクエストの提出
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@
 
 ## Reporting a Vulnerability
 
-セキュリティーに関する不具合は Issue ではなく、GitHub Security Advisories から Draft Advisory を生成してください。
+セキュリティーに関する不具合は Issue ではなく、[GitHub Security Advisories から Draft Advisory を作成](https://github.com/approvers/OreOreBot2/security/advisories/new)してください。
 
 脆弱性だと判断され次第、Security Advisories に掲載されます。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,15 +12,10 @@
 
 ## Reporting a Vulnerability
 
-セキュリティーに関する不具合は Issue ではなく、以下のいずれかの方法で報告を行ってください。
+セキュリティーに関する不具合は Issue ではなく、GitHub Security Advisories から Draft Advisory を生成してください。
 
-1. `me@mel9y.dev` 宛に以下の GPG 鍵で署名したメールを送信する
-   鍵指紋: `78E4 CFE0 B3B2 0C4C 7BAA A3CA 6554 A829 D251 53F9` , [pgp_keys.asc](https://keybase.io/m2en/pgp_keys.asc?fingerprint=78e4cfe0b3b20c4c7baaa3ca6554a829d25153f9)
-2. [GitHub Security Advisories](https://github.com/approvers/OreOreBot2/security/advisories/new) からセキュリティ勧告を作成する
+脆弱性だと判断され次第、Security Advisories に掲載されます。
 
-報告を行う際は以下の情報を詳細に記載してください。
+作成方法については GitHub Docs を確認してください。
 
-- `Impact` - どのような脆弱性で、誰が影響を受けるのか
-- `Process` - 問題を再現するための手段
-- `PoC` - 概念実証。脆弱性を利用した攻撃が可能であることを示す実際のコード (可能であれば)
-- `Version` - 脆弱性が存在するバージョン
+[Creating a repository security advisory - GitHub Docs](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/creating-a-repository-security-advisory)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,22 +12,15 @@
 
 ## Reporting a Vulnerability
 
-OreOreBot2 自身の脆弱性を発見した際は **[me@m2en.dev](mailto:me@m2en.dev) 宛に下記 PGP 鍵で暗号化を施して** ご連絡ください。
-当リポジトリの Issue や、Twitter の公開スレッドなど、外部から見えてしまう場所での報告はご遠慮ください。
+セキュリティーに関する不具合は Issue ではなく、以下のいずれかの方法で報告を行ってください。
 
-暗号化を行う際の PGP 鍵は以下の通りです。
+1. `me@mel9y.dev` 宛に以下の GPG 鍵で署名したメールを送信する
+   鍵指紋: `78E4 CFE0 B3B2 0C4C 7BAA A3CA 6554 A829 D251 53F9` , [pgp_keys.asc](https://keybase.io/m2en/pgp_keys.asc?fingerprint=78e4cfe0b3b20c4c7baaa3ca6554a829d25153f9)
+2. [GitHub Security Advisories](https://github.com/approvers/OreOreBot2/security/advisories/new) からセキュリティ勧告を作成する
 
-鍵指紋: `78E4 CFE0 B3B2 0C4C 7BAA A3CA 6554 A829 D251 53F9`
+報告を行う際は以下の情報を詳細に記載してください。
 
-[pgp_keys.asc](https://keybase.io/m2en/pgp_keys.asc?fingerprint=78e4cfe0b3b20c4c7baaa3ca6554a829d25153f9)
-
-また、これらの脆弱性をより早く解決するために、以下の情報をできる限り多く提供してください。
-
-- 脆弱性の種類
-  - (例: SQL インジェクション、コード・インジェクション、リソース管理の問題、設計上の問題、認可・権限・アクセス制御)
-- 脆弱性に関連するソースファイルのフルパス
-- 脆弱性に関連するソースコードのタグ、コミットハッシュ、permlink など
-- 脆弱性を再現するために必要な特別な設定
-- 問題を再現するための手順
-- PoC(概念実証)(可能であれば)
-- 脆弱性の影響
+- `Impact` - どのような脆弱性で、誰が影響を受けるのか
+- `Process` - 問題を再現するための手段
+- `PoC` - 概念実証。脆弱性を利用した攻撃が可能であることを示す実際のコード (可能であれば)
+- `Version` - 脆弱性が存在するバージョン


### PR DESCRIPTION
### Type of Change:

修正(ドキュメント)

### Details of implementation (実施内容)

Security Policy と Contributing Guide ともに記述されている **セキュリティーに関する不具合の報告** にて２つの間に齟齬が見られているので修正しました。

----

#### 修正した齟齬
- Contributing Guide 側には GitHub Security Advisories からの報告方法が書いてあるが、 Security Policy 側には記述がない