### PR TITLE
build(docker): Bump python3 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src
 
 # node-gyp requires Python and basic packages needed to compile C libs
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3=3.9.2-3 build-essential=12.9 \
+    && apt-get install -y --no-install-recommends python3=3.11.2-1+b1 build-essential=12.9 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Type of Change:

Dockerfile の修正

### Details of implementation (実施内容)

`node:20-slim` の suite が更新された影響で利用可能な Python のバージョンが変わったので, インストールするバージョンを更新しました.
