### PR TITLE
feat: Discord の新ユーザーネームシステムに対応する

### DIFF
--- a/src/adaptor/discord/member-stats.ts
+++ b/src/adaptor/discord/member-stats.ts
@@ -108,7 +108,11 @@ export class DiscordMemberStats
       joinedAt,
       createdAt,
       bot: member.user.bot,
-      tag: member.user.tag,
+      /**
+       * "#0" がついたユーザーネーム(新システム)から取り除くの処理は user-info.ts 側で行う
+       * https://github.com/approvers/OreOreBot2/issues/914
+       */
+      userName: member.user.tag,
       hoistRoleId: hoistRoleId
     };
   }

--- a/src/service/command/user-info.test.ts
+++ b/src/service/command/user-info.test.ts
@@ -20,7 +20,7 @@ describe('UserInfo', () => {
               joinedAt: new Date(20050902),
               createdAt: new Date(20050902),
               bot: false,
-              tag: 'm2en#0092',
+              userName: 'meru',
               hoistRoleId: '865951894173515786' as Snowflake
             }
           : null
@@ -57,8 +57,8 @@ describe('UserInfo', () => {
           inline: true
         },
         {
-          name: 'ユーザー名+Discord Tag',
-          value: 'm2en#0092',
+          name: 'ユーザーネーム',
+          value: 'meru',
           inline: true
         },
         {
@@ -120,8 +120,8 @@ describe('UserInfo', () => {
           inline: true
         },
         {
-          name: 'ユーザー名+Discord Tag',
-          value: 'm2en#0092',
+          name: 'ユーザーネーム',
+          value: 'meru',
           inline: true
         },
         {
@@ -171,6 +171,94 @@ describe('UserInfo', () => {
     expect(fn).toHaveBeenCalledWith({
       title: '引数エラー',
       description: '指定したユーザーは存在しないよ'
+    });
+    expect(fetchStats).toHaveBeenCalledOnce();
+  });
+});
+
+// "UserInfo" として定義してもいいが、見通し良くするために新しいスイートを定義する
+describe('BotInfo', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const repo: UserStatsRepository = {
+    fetchUserStats: (id) =>
+      Promise.resolve(
+        id === '279614913129742338'
+          ? {
+              color: 'f08f8f',
+              displayName: 'さいな',
+              joinedAt: new Date(20230721),
+              createdAt: new Date(20230721),
+              bot: true,
+              userName: 'mikuro#2796',
+              hoistRoleId: '865951894173515786' as Snowflake
+            }
+          : null
+      )
+  };
+  const userInfo = new UserInfo(repo);
+
+  it('gets info bot user (old username system)', async () => {
+    const fetchStats = vi.spyOn(repo, 'fetchUserStats');
+    const fn = vi.fn();
+
+    await userInfo.on(
+      createMockMessage(
+        parseStringsOrThrow(
+          ['userinfo', '279614913129742338'],
+          userInfo.schema
+        ),
+        fn
+      )
+    );
+
+    expect(fn).toHaveBeenCalledWith({
+      title: 'ユーザーの情報',
+      description: '司令官、頼まれていた <@279614913129742338> の情報だよ',
+      fields: [
+        {
+          name: 'ID',
+          value: '279614913129742338',
+          inline: true
+        },
+        {
+          name: '表示名',
+          value: 'さいな',
+          inline: true
+        },
+        {
+          name: 'ユーザーネーム',
+          value: 'mikuro#2796',
+          inline: true
+        },
+        {
+          name: 'プロフィールカラー',
+          value: 'f08f8f',
+          inline: true
+        },
+        {
+          name: 'ユーザ種別',
+          value: 'ボット',
+          inline: true
+        },
+        {
+          name: 'メンバーリストの分類ロール',
+          value: '<@&865951894173515786>',
+          inline: true
+        },
+        {
+          name: 'サーバー参加日時',
+          value: `<t:20230>(<t:20230:R>)`,
+          inline: true
+        },
+        {
+          name: 'アカウント作成日時',
+          value: `<t:20230>(<t:20230:R>)`,
+          inline: true
+        }
+      ]
     });
     expect(fetchStats).toHaveBeenCalledOnce();
   });

--- a/src/service/command/user-info.test.ts
+++ b/src/service/command/user-info.test.ts
@@ -20,7 +20,7 @@ describe('UserInfo', () => {
               joinedAt: new Date(20050902),
               createdAt: new Date(20050902),
               bot: false,
-              userName: 'meru',
+              userName: 'meru#0',
               hoistRoleId: '865951894173515786' as Snowflake
             }
           : null

--- a/src/service/command/user-info.ts
+++ b/src/service/command/user-info.ts
@@ -93,7 +93,7 @@ export class UserInfo implements CommandResponder<typeof SCHEMA> {
         inline: true
       },
       {
-        name: 'ユーザネーム',
+        name: 'ユーザーネーム',
         value: createUserNameDisplay(userName),
         inline: true
       },

--- a/src/service/command/user-info.ts
+++ b/src/service/command/user-info.ts
@@ -12,7 +12,7 @@ export interface UserStats {
   joinedAt?: Date;
   createdAt: Date;
   bot: boolean;
-  tag: string;
+  userName: string;
   hoistRoleId?: Snowflake | undefined;
 }
 
@@ -76,7 +76,7 @@ export class UserInfo implements CommandResponder<typeof SCHEMA> {
       joinedAt,
       createdAt,
       bot,
-      tag,
+      userName,
       hoistRoleId
     }: UserStats,
     userId: string
@@ -93,8 +93,8 @@ export class UserInfo implements CommandResponder<typeof SCHEMA> {
         inline: true
       },
       {
-        name: 'ユーザー名+Discord Tag',
-        value: tag,
+        name: 'ユーザネーム',
+        value: createUserNameDisplay(userName),
         inline: true
       },
       {
@@ -138,10 +138,19 @@ function fetchUserId(arg: string, senderId: string): string {
   }
   return arg;
 }
+
 function createHoistRoleDisplay(hoistRoleId: Snowflake | undefined): string {
   if (!hoistRoleId) {
     return 'なし';
   }
 
   return `<@&${hoistRoleId}>`;
+}
+
+function createUserNameDisplay(userName: string): string {
+  if (userName.endsWith('#0')) {
+    // Discordのユーザー名に"#"を使うことは出来ないのでそのまま replace しても問題ない
+    return userName.replace('#0', '');
+  }
+  return userName;
 }


### PR DESCRIPTION
close #914 

### Type of Change:

新規追加 (既存機能の変更)

### Details of implementation (実施内容)

Discord の新ユーザーネームシステムに対応しました。 ( `#` による識別タグが廃止されたシステム)

- 新システムに移行済みのユーザーはユーザーネームの最後に `#0` が付与された状態で Discord API が応答します。そのため、その `#0` を取り除く形で対応しました。
- 未変更のユーザー、新システム移行が始まっていないBot はまだ識別タグがあるためそのようなユーザー、Botに対して検索を実行した場合識別タグを今まで通り表示します。
- 埋め込み(Embed)のフィールド名は `ユーザーネーム` に統一しました。
- テストケースは識別タグを取り除かないパターン (識別タグがまだあるユーザーに対しての検索)を新しく追加しています。