### PR TITLE
feat: ユーザー情報としてユーザーのアバターをサポートするように

### DIFF
--- a/src/adaptor/discord/member-stats.ts
+++ b/src/adaptor/discord/member-stats.ts
@@ -102,6 +102,8 @@ export class DiscordMemberStats
       (member.roles.hoist?.id as Snowflake | null) ?? undefined;
     const createdAt = member.user.createdAt;
 
+    const displayAvatarURL = member.displayAvatarURL();
+
     return {
       color: member.displayColor.toString(16).padStart(6, '0'),
       displayName: member.displayName,
@@ -113,7 +115,8 @@ export class DiscordMemberStats
        * https://github.com/approvers/OreOreBot2/issues/914
        */
       userName: member.user.tag,
-      hoistRoleId: hoistRoleId
+      hoistRoleId: hoistRoleId,
+      avatarUrl: displayAvatarURL
     };
   }
 

--- a/src/service/command/user-info.test.ts
+++ b/src/service/command/user-info.test.ts
@@ -21,7 +21,8 @@ describe('UserInfo', () => {
               createdAt: new Date(20050902),
               bot: false,
               userName: 'meru#0',
-              hoistRoleId: '865951894173515786' as Snowflake
+              hoistRoleId: '865951894173515786' as Snowflake,
+              avatarUrl: 'https://example.com/meru.png'
             }
           : null
       )
@@ -86,7 +87,8 @@ describe('UserInfo', () => {
           value: `<t:20050>(<t:20050:R>)`,
           inline: true
         }
-      ]
+      ],
+      thumbnail: { url: 'https://example.com/meru.png' }
     });
     expect(fetchStats).toHaveBeenCalledOnce();
   });
@@ -149,7 +151,8 @@ describe('UserInfo', () => {
           value: `<t:20050>(<t:20050:R>)`,
           inline: true
         }
-      ]
+      ],
+      thumbnail: { url: 'https://example.com/meru.png' }
     });
     expect(fetchStats).toHaveBeenCalledOnce();
   });
@@ -193,7 +196,8 @@ describe('BotInfo', () => {
               createdAt: new Date(20230721),
               bot: true,
               userName: 'mikuro#2796',
-              hoistRoleId: '865951894173515786' as Snowflake
+              hoistRoleId: '865951894173515786' as Snowflake,
+              avatarUrl: 'https://example.com/mikuro.png'
             }
           : null
       )
@@ -258,7 +262,8 @@ describe('BotInfo', () => {
           value: `<t:20230>(<t:20230:R>)`,
           inline: true
         }
-      ]
+      ],
+      thumbnail: { url: 'https://example.com/mikuro.png' }
     });
     expect(fetchStats).toHaveBeenCalledOnce();
   });

--- a/src/service/command/user-info.ts
+++ b/src/service/command/user-info.ts
@@ -14,6 +14,7 @@ export interface UserStats {
   bot: boolean;
   userName: string;
   hoistRoleId?: Snowflake | undefined;
+  avatarUrl: string;
 }
 
 export interface UserStatsRepository {
@@ -77,7 +78,8 @@ export class UserInfo implements CommandResponder<typeof SCHEMA> {
       createdAt,
       bot,
       userName,
-      hoistRoleId
+      hoistRoleId,
+      avatarUrl
     }: UserStats,
     userId: string
   ) {
@@ -127,7 +129,8 @@ export class UserInfo implements CommandResponder<typeof SCHEMA> {
     return {
       title: `ユーザーの情報`,
       description: `司令官、頼まれていた <@${userId}> の情報だよ`,
-      fields
+      fields,
+      thumbnail: { url: avatarUrl }
     };
   }
 }


### PR DESCRIPTION
### Type of Change:

新規追加

### Details of implementation (実施内容)

- `!userinfo` ( `!user` ) で表示されるユーザー情報に新しくアバター画像をサポートしました。
- ギルド別のアバター画像が設定されている場合はその画像を表示し、設定されていない場合はユーザーのアバター画像を表示します。 (常に優先されて表示されるのはギルド別のアバター画像です。)
- アバター画像が設定されていない場合は初期設定のアバター画像が表示されます。 ( djs から提供されるURL)