### PR TITLE
fix: 再接続の制御を除去

### DIFF
--- a/src/adaptor/discord/voice.ts
+++ b/src/adaptor/discord/voice.ts
@@ -111,11 +111,7 @@ export class DiscordVoiceConnection<K extends string | number | symbol>
     this.connection = joinVoiceChannel({
       channelId: this.channel.id,
       guildId: this.channel.guildId,
-      adapterCreator: this.channel.guild.voiceAdapterCreator,
-      debug: true
-    });
-    this.connection.on('stateChange', (from, to) => {
-      console.log({ from, to });
+      adapterCreator: this.channel.guild.voiceAdapterCreator
     });
   }
   destroy(): void {

--- a/src/service/command/gyokuon.ts
+++ b/src/service/command/gyokuon.ts
@@ -84,7 +84,6 @@ export class GyokuonCommand implements CommandResponder<typeof SCHEMA> {
     connectionVC.connect();
     connectionVC.onDisconnected(() => {
       this.doingGyokuon = false;
-      return false;
     });
 
     if (isShort) {

--- a/src/service/command/kaere.ts
+++ b/src/service/command/kaere.ts
@@ -184,7 +184,6 @@ export class KaereCommand implements CommandResponder<typeof SCHEMA> {
     connection.connect();
     connection.onDisconnected(() => {
       this.doingKaere = false;
-      return false;
     });
     await this.deps.stdout.sendEmbed({
       title: '提督、もうこんな時間だよ',

--- a/src/service/command/party.ts
+++ b/src/service/command/party.ts
@@ -188,7 +188,6 @@ export class PartyCommand implements CommandResponder<typeof SCHEMA> {
     this.connection.connect();
     this.connection.onDisconnected(() => {
       this.connection = null;
-      return false;
     });
     await message.reply(partyStarting);
     await this.connection.playToEnd(this.generateNextKey());

--- a/src/service/voice-connection.ts
+++ b/src/service/voice-connection.ts
@@ -54,9 +54,7 @@ export interface VoiceConnection<K> {
   unpause(): void;
 
   /**
-   * 回復できない接続解除が発生した時に、同じチャンネルへ再接続するかどうかのハンドラを登録する。ボイスチャンネルが削除されたなど、必ず再接続できないこともある。
-   *
-   * @param shouldReconnect - この関数が `true` を返す場合は、回復できない接続解除でも同じチャンネルへの再接続を試みる。
+   * 接続解除が発生した時のハンドラを登録する。
    */
-  onDisconnected(shouldReconnect: () => boolean): void;
+  onDisconnected(handler: () => void): void;
 }


### PR DESCRIPTION
close #958

### Type of Change:

音声接続処理の仕様変更

### Cause of the Problem (問題の原因)

切断時のハンドラが再接続すべきかどうかの判断を兼ねていましたが, これは再接続できるかもしれない状況で呼び出されるので, 強制切断された際には呼び出されていませんでした.

### Dealing with Problems (問題への対処)

そもそも再接続することが好ましくないことが多く, ハンドラに機能を持たせすぎていたので, この再接続を制御する機能を除去し, あらゆる切断された状況でもハンドラが呼び出されるようにしました.

### Details of implementation (実施内容)

`VoiceConnection` の引数の仕様を変更し, それを利用していたコードの記述を修正しました. そして再接続処理のコードをすべて除去しました.
