### PR TITLE
build: ビルドされたコードの縮小

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node ./build/index.js",
     "dev": "ts-node --esm ./src/server/index.ts",
-    "build": "esbuild ./src/server/index.ts --bundle --platform=node  --target=node16 --format=esm --packages=external --outfile=build/index.js",
+    "build": "esbuild ./src/server/index.ts --bundle --minify --charset=utf8 --platform=node --target=node16 --format=esm --packages=external --outfile=build/index.js",
     "format": "prettier --write \"src/**/*.{js,ts,md}\"",
     "check": "prettier --check \"src/**/*.{js,ts,md}\" && tsc -p . --noEmit",
     "eslint": "eslint \"src/**/*.{js,ts,md}\"",


### PR DESCRIPTION
### Type of Change:

ビルド方法の変更

### Cause of the Problem (問題の原因)

現在このプロジェクトではESBuildを用いてビルドを行っていますが，ビルドオプションが最適ではなく，ファイルサイズが増加していました．

### Dealing with Problems (問題への対処)

上記の問題に対処するためにビルドオプションをいくつか追加し，最適なサイズのファイルが生成されるようにしました．

これにより140kBほどだったコードが71kBに縮小されました．

### Details of implementation (実施内容)

- `--minify`の追加．これはコードをMinifyするようになります．
- `--charset=utf8`の追加．これはUTF-8のコードポイントをエスケープしなくなります．今まではASCIIの範囲に収まらない場合は`\uXXXX`の形式でエスケープされていました．

### Additional Information (追加情報)

`--charset=utf8`を追加する場合，そのコードが確実にUTF-8として解釈される必要があります．

[ESBuildのcharsetに関するドキュメント](https://esbuild.github.io/api/#charset)