### PR TITLE
fix: 選択肢のパース処理の修正

### DIFF
--- a/src/adaptor/proxy/command/slash.test.ts
+++ b/src/adaptor/proxy/command/slash.test.ts
@@ -145,11 +145,11 @@ test('multi args', () => {
     ]
   } as const;
 
-  function argsToOptions(args: string[]) {
+  function argsToOptions(args: (string | undefined)[]) {
     return {
       index: 0,
       getString() {
-        const ret = args[this.index];
+        const ret = args[this.index] ?? null;
         ++this.index;
         return ret;
       }
@@ -159,8 +159,7 @@ test('multi args', () => {
   const noParamRes = parseOptions(
     'd',
     argsToOptions([
-      '1d100',
-      's'
+      '1d100'
     ]) as unknown as ChatInputCommandInteraction['options'],
     DICE_SCHEMA
   );

--- a/src/adaptor/proxy/command/slash.ts
+++ b/src/adaptor/proxy/command/slash.ts
@@ -139,13 +139,12 @@ const parseParams = <S extends Schema | SubCommand>(
         const val = options.getString(param.name, false);
         if (val === null) {
           if (param.defaultValue !== undefined) {
-            const defaultChoice = param.choices[param.defaultValue];
-            result.push(defaultChoice);
+            result.push(param.defaultValue);
             break;
           }
           return ['Err', ['NEED_MORE_ARGS']];
         }
-        result.push(val);
+        result.push(param.choices.indexOf(val));
         break;
       }
       case 'VARIADIC': {


### PR DESCRIPTION
Resolves #978.

### Type of Change:

バグの修正

### Cause of the Problem (問題の原因)

選択肢のオプション `CHOICES` だったときのパース結果が選択肢のインデックスになっておらず, 選択した値そのものになっていました.

### Details of implementation (実施内容)

正しくは選択した値が何番目かを取り出すようにすべきだったので, そのように修正しました.
