### PR TITLE
chore: GitHub Sponsors の設定ファイルに限界開発鯖Orgを指定する

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-github: [m2en, shun-shobon, su8ru]
+# 本来 approvers/.github にある FUNDING.yml が使われるが、リポジトリで上書きしている場合は別途で指定が必要
+github: [approvers, m1sk9, shun-shobon, su8ru]


### PR DESCRIPTION
### Details of implementation (実施内容)

- GitHub Sponsors のボタンに表示するユーザーリストに新しく `approvers` を追加しました.
