### PR TITLE
chore: 設定ファイルを Docker Compose v2 へ移行

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: ghcr.io/approvers/oreorebot2:v1
+    restart: always
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "3.9"
-
-services:
-  oreorebot2:
-    image: ghcr.io/approvers/oreorebot2:latest
-    restart: always
-    env_file:
-      - .env


### PR DESCRIPTION
### Details of implementation (実施内容)

2023年7月以降, Docker Compose v1 ( `docker-compose.yml` などが設定ファイルとなる Compose バージョン) は廃止され非推奨になりました. (セキュリティアップデートも降ってきません.)

それに伴いリポジトリ内の `docker-compose.yml` と `compose.yaml` に変更し, Docker Compose v2 に移行しました.

これに伴い Docker Compose v1 への後方互換性を実質的に破壊することになります.

参考: [Docker Compose release notes - docker docs](https://docs.docker.com/compose/release-notes/)
