### PR TITLE
ci: Release CI の挙動を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
-          path: ./packages/bot/
-          changelog-path: ./CHANGELOG.md
           token: ${{ steps.token.outputs.token }}
           release-type: node
           command: manifest

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,11 @@
 {
     "last-release-sha": "e5023238cace2f625076d32075090e4eecce219d",
-    "release-type": "node",
     "packages": {
-        ".": {}
+        ".": {},
+        "packages/bot": {
+            "release-type": "node",
+            "package-name": "OreOreBot2",
+            "changelog-path": "./CHANGELOG.md"
+        }
     }
 }


### PR DESCRIPTION
### Details of implementation (実施内容)

Yarn Workspaces への移行後 ( #1056 ) , Release CI が Monorepo 体制に対応できず CI が正しい挙動をしなくなっていたため修正を行いました. ( #1057 )