### PR TITLE
ci: CHANGELOG.md へのパスを修正

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,11 @@
 {
     "last-release-sha": "e5023238cace2f625076d32075090e4eecce219d",
+    "changelog-path": "./CHANGELOG.md",
     "packages": {
         ".": {},
         "packages/bot": {
             "release-type": "node",
-            "package-name": "OreOreBot2",
-            "changelog-path": "./CHANGELOG.md"
+            "package-name": "OreOreBot2"
         }
     }
 }


### PR DESCRIPTION

### Details of implementation (実施内容)

#1058 マージ後, `changelog-path` が不正だったためそれを修正しました.