### PR TITLE
ci: last-release-sha フィールドの削除

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-    "last-release-sha": "e5023238cace2f625076d32075090e4eecce219d",
     "changelog-path": "CHANGELOG.md",
     "packages": {
         "packages/bot": {


### PR DESCRIPTION

### Details of implementation (実施内容)

本来削除すべき `last-release-sha` フィールドが残留してしまっていたため, これを削除しました