### PR TITLE
ci last-release-sha フィールドを指定

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+    "last-release-sha": "8947b7552291304f530687e468fdeb2611c966cf",
     "changelog-path": "CHANGELOG.md",
     "packages": {
         "packages/bot": {


### PR DESCRIPTION

### Details of implementation (実施内容)

#1065 で削除した `last-release-sha` フィールドですが, 正しくリリース戦略を決めることが出来ていないようなので再び指定します.