### PR TITLE
ci(fix): リリースPRマージ後のCIで "Publish the Docker package" が実行されない問題の修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           command: manifest
 
       - name: Publish the Docker package
-        if: steps.release.outputs.release_created
+        if: steps.release.outputs.releases_created
         uses: ./.github/actions/publish
         with:
           major: ${{ steps.release.outputs.major }}


### PR DESCRIPTION
### Details of implementation (実施内容)

Step の実行条件を修正してみました. これで動くはずです.
