### PR TITLE
docs: ページ編集ボタンのリンクを新しいものに変更する

### DIFF
--- a/packages/docs/theme.config.tsx
+++ b/packages/docs/theme.config.tsx
@@ -18,7 +18,7 @@ const themeConfig: DocsThemeConfig = {
       </span>
     </>
   ),
-  docsRepositoryBase: `${pkg.repository}/blob/main/docs`,
+  docsRepositoryBase: `${pkg.repository}/edit/main/packages/docs`,
   primaryHue: 193,
   project: {
     link: pkg.repository


### PR DESCRIPTION
### Details of implementation (実施内容)

#1056 により, ページ編集ボタンのリンクが古いものになっていたので新しいものに変更しました. また直接編集ページに行けるようにしています.
