### PR TITLE
docs(fix): 間違っているパーティーのBGM IDを修正

### DIFF
--- a/packages/docs/src/pages/references/commands/voice/party.mdx
+++ b/packages/docs/src/pages/references/commands/voice/party.mdx
@@ -69,4 +69,4 @@ import { CommandArgs } from '../../../../organisms/command-args';
 | COFFIN_DROP                                         | [Coffin Dance](https://www.youtube.com/watch?v=j9V78UbdzWI)                         |
 | KAKAPO                                              | 不明                                                                                |
 | KAKUSIN_DAISUKE <VersionBadge>v1.9.0</VersionBadge> | [LeaF - Twitter](https://twitter.com/7eaF/status/1509153813235892229)               |
-| PATATO <VersionBadge>v1.33.0</VersionBadge>         | [【マクドナルド公式】ティロリサウンド](https://www.youtube.com/watch?v=8NjhfastLts) |
+| POTATO <VersionBadge>v1.33.0</VersionBadge>         | [【マクドナルド公式】ティロリサウンド](https://www.youtube.com/watch?v=8NjhfastLts) |


### PR DESCRIPTION
### Details of implementation (実施内容)

[`PATATO` -> `POTATO`](https://haracho.approvers.dev/references/commands/voice/party#%E3%81%AF%E3%82%89%E3%81%A1%E3%82%87%E3%81%8C%E6%8F%90%E4%BE%9B%E3%81%99%E3%82%8B-bgm) でした.
