### PR TITLE
fix: ロゴ画像のパスを修正

### DIFF
--- a/packages/docs/theme.config.tsx
+++ b/packages/docs/theme.config.tsx
@@ -8,7 +8,7 @@ const themeConfig: DocsThemeConfig = {
   logo: (
     <>
       <Image
-        src={'./assets/haracho-transmission.png'}
+        src={'/assets/haracho-transmission.png'}
         width={50}
         height={50}
         alt={'はらちょのアイコン'}


### PR DESCRIPTION
close #1087

### Type of Change:

設定の修正

### Cause of the Problem (問題の原因)

ロゴ画像のパスが相対パスになっており, 最初に開いたページによってはパス解決に失敗していました.

### Details of implementation (実施内容)

画像のパスを絶対パスへと変更しました.
