### PR TITLE
ci: docsのビルドをキャッシュ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,14 @@ jobs:
           node-version: '18'
           cache: yarn
 
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/packages/docs/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yan.lock') }}-${{ hashFiles('packages/docs/**/*.js', 'packages/docs/**/*.jsx', 'packages/docs/**/*.ts', 'packages/docs/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/yan.lock') }}-
+
       - name: Install packages
         run: yarn install --immutable
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/packages/docs/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yan.lock') }}-${{ hashFiles('packages/docs/**/*.js', 'packages/docs/**/*.jsx', 'packages/docs/**/*.ts', 'packages/docs/**/*.tsx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yan.lock') }}-${{ hashFiles('packages/docs/**/*.js', 'packages/docs/**/*.jsx', 'packages/docs/**/*.ts', 'packages/docs/**/*.tsx', 'packages/docs/**/*.mdx', 'packages/docs/**/*.json') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/yan.lock') }}-
 


### PR DESCRIPTION
close #1108.

### Type of Change:

CI の変更

### Details of implementation (実施内容)

docs 配下のファイルのハッシュをキャッシュのキーとして, Next.js のビルド成果物をキャッシュするようにしました.
