### PR TITLE
ci: リリース CI の workflow_dispatch を差し戻す

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 
 name: Release
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
### Type of Change:

CI の変更

### Details of implementation (実施内容)

リリース CI のやり直しを容易にするために, 過去に実行条件として指定していた `workflow_dispatch` を適用し直しました.
