### PR TITLE
fix(docs): emoji-seq development guide url

### DIFF
--- a/packages/docs/src/pages/development/emoji-seq.mdx
+++ b/packages/docs/src/pages/development/emoji-seq.mdx
@@ -4,7 +4,7 @@
 
 ---
 
-EmojiSeq の設定ファイルは [`assets/`](https://github.com/approvers/OreOreBot2/blob/main/assets/emoji-seq.yaml) に存在します。
+EmojiSeq の設定ファイルは [`packages/bot/ssets/`](https://github.com/approvers/OreOreBot2/blob/main/packages/bot/assets/emoji-seq.yaml) に存在します。
 
 このファイルを編集することで、新しいパターンを追加することができます。
 


### PR DESCRIPTION
### Details of implementation (実施内容)

[emoji-seq 追加ガイド](https://haracho.approvers.dev/development/emoji-seq)にリンク切れが発生していたため, 修正しました.