### PR TITLE
ci: publish の入力引数の修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
           token: ${{ steps.token.outputs.token }}
 
       - name: Publish the Docker package
-        if: steps.release.outputs.releases_created
+        if: steps.release.outputs['packages/bot--releases_created']
         uses: ./.github/actions/publish
         with:
-          major: ${{ steps.release.outputs.major }}
-          minor: ${{ steps.release.outputs.minor }}
-          patch: ${{ steps.release.outputs.patch }}
-          sha: ${{ steps.release.outputs.sha }}
+          major: ${{ steps.release.outputs['packages/bot--major'] }}
+          minor: ${{ steps.release.outputs['packages/bot--minor'] }}
+          patch: ${{ steps.release.outputs['packages/bot--patch'] }}
+          sha: ${{ steps.release.outputs['packages/bot--sha'] }}


### PR DESCRIPTION
Fix #1148.

### Type of Change:

CI の修正

### Cause of the Problem (問題の原因)

#1148 のコメントをご覧ください.

### Details of implementation (実施内容)

release ステップの出力を正しく参照するように, オブジェクトへのアクセスを修正しました.
