### PR TITLE
fix(ci): fix problem with incorrect tagValue passed by release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@
 
 name: Release
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -10,6 +9,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +29,7 @@ jobs:
           token: ${{ steps.token.outputs.token }}
 
       - name: Publish the Docker package
-        if: steps.release.outputs.releases_created
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: ./.github/actions/publish
         with:
           major: ${{ steps.release.outputs['packages/bot--major'] }}


### PR DESCRIPTION
close #1148 

### Details of implementation (実施内容)

~~`release-please` が受け渡すタグ値が不正な問題について `steps.release.outputs.releases_created` から値を受け渡してもらえるようにしてみました. 直るかどうかはもう知りません.~~

v4 では `steps.release.outputs.releases_created` で不具合が起きているようです. 一度上の変更は取り消して if式 を修正してみました. 直るかどうかはもう知りません.

See also: https://github.com/google-github-actions/release-please-action/issues/912