### PR TITLE
ci: publish の checkout に ref オプションを追加して inputs.sha を指定

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
close #1224.

### Type of Change:

GitHub Action の修正

### Details of implementation (実施内容)

今まで `main` ブランチの `HEAD` を利用してイメージを作成していたのを, `inputs.sha` のコミットを参照して作成するように変更しました.