### PR TITLE
ci: `inputs.sha` を指定せずに publish ci を実行できるように

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,6 @@ on:
         description: Patch version number
         required: true
         type: string
-      sha:
-        description: Git SHA
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       major:
@@ -31,10 +27,6 @@ on:
         type: string
       patch:
         description: Patch version number
-        required: true
-        type: string
-      sha:
-        description: Git SHA
         required: true
         type: string
 


### PR DESCRIPTION
### Details of implementation (実施内容)

#1225 で sha ハッシュは `actions/checkout` v4 から提供される値を使用するようになったが, 手動リリースなどのときにメンテナ側が指定しないとリリースが実行できなくなってしまっていたため, 修正.