### PR TITLE
build: bot パッケージのディレクトリを WORKDIR に指定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,7 @@ COPY --from=build /build .
 COPY --from=build /build/packages ./packages
 COPY --from=build /build/packages/bot ./packages/bot
 
+WORKDIR /app/packages/bot
+
 ENTRYPOINT ["node"]
-CMD ["packages/bot/build/index.mjs"]
+CMD ["build/index.mjs"]


### PR DESCRIPTION
close #1229.

### Type of Change:

Dockerfile の修正

### Details of implementation (実施内容)

ワーキングディレクトリが変化したために動作しなくなっていたので, WORKDIR で改めて指定するようにしました. もっといいやり方があるかもしれません.
