### PR TITLE
docs: `/kaere` ・ `/party` での即時実行に関する注記追加

### DIFF
--- a/packages/docs/src/pages/references/commands/voice/kaere.mdx
+++ b/packages/docs/src/pages/references/commands/voice/kaere.mdx
@@ -1,5 +1,6 @@
 import { Callout } from 'nextra-theme-docs';
 
+import { VersionBadge } from '../../../../molecules/version-badge';
 import { CommandArgs } from '../../../../organisms/command-args';
 
 # Kaere 一葉
@@ -13,6 +14,12 @@ VC 内の人類に就寝を促します。引数なしで即時発動
 <Callout type="warning">
 
 この機能には FFmpeg が必要です。
+
+</Callout>
+
+<Callout type="info">
+
+スラッシュコマンドを使用している場合の即時発動は `/kaere start` で行なえます。 (<VersionBadge children={'v1.48.0'} /> から利用可能)
 
 </Callout>
 

--- a/packages/docs/src/pages/references/commands/voice/party.mdx
+++ b/packages/docs/src/pages/references/commands/voice/party.mdx
@@ -5,7 +5,7 @@ import { CommandArgs } from '../../../../organisms/command-args';
 
 # Party 一葉
 
-<CommandArgs versionAvailableFrom="v1.0.0" commandName="kaere" />
+<CommandArgs versionAvailableFrom="v1.0.0" commandName="party" />
 
 ---
 
@@ -14,6 +14,12 @@ import { CommandArgs } from '../../../../organisms/command-args';
 <Callout type="warning">
 
 この機能には FFmpeg が必要です。
+
+</Callout>
+
+<Callout type="info">
+
+スラッシュコマンドを使用している場合の即時発動は `/party start` で行なえます。 (<VersionBadge children={'v1.48.0'} /> から利用可能)
 
 </Callout>
 


### PR DESCRIPTION

### Details of implementation (実施内容)

#1111 で追加された `/kaere start` ・ `/party start` に関する注記の追加