### PR TITLE
feat: メッセージが投稿後３秒以内に削除された場合に特殊メッセージを送信するように変更

### DIFF
--- a/packages/bot/src/adaptor/proxy/middleware/message-convert.ts
+++ b/packages/bot/src/adaptor/proxy/middleware/message-convert.ts
@@ -26,6 +26,7 @@ const observableMessage = (
   authorId: getAuthorSnowflake(raw),
   author: raw.author?.username ?? '名無し',
   content: raw.content ?? '',
+  createdAt: raw.createdAt,
   async sendEphemeralToSameChannel(message: string): Promise<void> {
     const FIVE_SECONDS_MS = 5000;
     const { channel } = raw;

--- a/packages/bot/src/server/index.ts
+++ b/packages/bot/src/server/index.ts
@@ -115,12 +115,13 @@ const standardOutput = new DiscordStandardOutput(client, mainChannelId);
 const entranceOutput = new DiscordEntranceOutput(client, entranceChannelId);
 
 const scheduleRunner = new ScheduleRunner(clock);
+const getCurrentDate = () => new Date();
 const messageCreateRunner = new MessageResponseRunner(
   new MessageProxy(client, middlewareForMessage())
 );
 if (features.includes('MESSAGE_CREATE')) {
   messageCreateRunner.addResponder(
-    allMessageEventResponder(typoRepo, sequencesYaml)
+    allMessageEventResponder(typoRepo, sequencesYaml, getCurrentDate)
   );
 
   startTimeSignal({

--- a/packages/bot/src/service/deletion-repeater.test.ts
+++ b/packages/bot/src/service/deletion-repeater.test.ts
@@ -3,10 +3,14 @@ import { expect, it, vi } from 'vitest';
 import { DeletionRepeater } from './deletion-repeater.js';
 
 it('react to deleted message', async () => {
+  const now = new Date();
+  now.setSeconds(now.getSeconds() - 10);
+
   const responder = new DeletionRepeater(() => false);
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Stop',
+    createdAt: now,
     sendEphemeralToSameChannel: (message) => {
       expect(message)
         .toEqual(`Babaさん、メッセージを削除しましたね？私は見ていましたよ。内容も知っています。
@@ -19,17 +23,24 @@ Wall Is Stop
 });
 
 it('must not react', async () => {
+  const now = new Date();
+  now.setSeconds(now.getSeconds() - 10);
+
   const responder = new DeletionRepeater(() => false);
   const fn = vi.fn();
   await responder.on('CREATE', {
     author: 'Baba',
     content: 'Wall Is Not Stop',
+    createdAt: now,
     sendEphemeralToSameChannel: fn
   });
   expect(fn).not.toHaveBeenCalled();
 });
 
 it("must not react if it's ignore target", async () => {
+  const now = new Date();
+  now.setSeconds(now.getSeconds() - 10);
+
   const responder = new DeletionRepeater(
     (content) => content === 'Wall Is Stop'
   );
@@ -37,18 +48,23 @@ it("must not react if it's ignore target", async () => {
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Stop',
+    createdAt: now,
     sendEphemeralToSameChannel: fn
   });
   expect(fn).not.toHaveBeenCalled();
 });
 
 it("must react if it's not ignore target", async () => {
+  const now = new Date();
+  now.setSeconds(now.getSeconds() - 10);
+
   const responder = new DeletionRepeater(
     (content) => content === 'Wall Is Stop'
   );
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Not Stop',
+    createdAt: now,
     sendEphemeralToSameChannel: (message) => {
       expect(message)
         .toEqual(`Babaさん、メッセージを削除しましたね？私は見ていましたよ。内容も知っています。

--- a/packages/bot/src/service/deletion-repeater.test.ts
+++ b/packages/bot/src/service/deletion-repeater.test.ts
@@ -75,3 +75,23 @@ Wall Is Not Stop
     }
   });
 });
+
+it("react to deleted message if it's too fast", async () => {
+  const now = new Date();
+  now.setSeconds(now.getSeconds() - 1);
+
+  const responder = new DeletionRepeater(() => false);
+  await responder.on('DELETE', {
+    author: 'Baba',
+    content: 'Wall Is Stop',
+    createdAt: now,
+    sendEphemeralToSameChannel: (message) => {
+      expect(message)
+        .toEqual(`Babaさんの恐ろしく早いメッセージの削除。私じゃなきゃ見逃していましたよ。
+\`\`\`
+Wall Is Stop
+\`\`\``);
+      return Promise.resolve();
+    }
+  });
+});

--- a/packages/bot/src/service/deletion-repeater.test.ts
+++ b/packages/bot/src/service/deletion-repeater.test.ts
@@ -2,19 +2,29 @@ import { expect, it, vi } from 'vitest';
 
 import { DeletionRepeater } from './deletion-repeater.js';
 
-it('react to deleted message', async () => {
-  const now = new Date();
-  const createdAt = new Date();
-  createdAt.setSeconds(createdAt.getSeconds() - 10);
+const createdDate = () => {
+  const now = new Date(2024, 1, 1, 0, 0, 30);
+  return now;
+};
 
-  const responder = new DeletionRepeater(
-    () => false,
-    () => now
-  );
+const deletedDate = () => {
+  // createdDateよりも10秒後
+  const createdAt = new Date(2024, 1, 1, 0, 0, 40);
+  return createdAt;
+};
+
+const fastDeletedDate = () => {
+  // createdDateよりも1秒後
+  const createdAt = new Date(2024, 1, 1, 0, 0, 31);
+  return createdAt;
+};
+
+it('react to deleted message', async () => {
+  const responder = new DeletionRepeater(() => false, deletedDate);
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Stop',
-    createdAt: createdAt,
+    createdAt: createdDate(),
     sendEphemeralToSameChannel: (message) => {
       expect(message)
         .toEqual(`Babaさん、メッセージを削除しましたね？私は見ていましたよ。内容も知っています。
@@ -27,56 +37,41 @@ Wall Is Stop
 });
 
 it('must not react', async () => {
-  const now = new Date();
-  const createdAt = new Date();
-  createdAt.setSeconds(now.getSeconds() - 10);
-
-  const responder = new DeletionRepeater(
-    () => false,
-    () => now
-  );
+  const responder = new DeletionRepeater(() => false, deletedDate);
   const fn = vi.fn();
   await responder.on('CREATE', {
     author: 'Baba',
     content: 'Wall Is Not Stop',
-    createdAt: createdAt,
+    createdAt: createdDate(),
     sendEphemeralToSameChannel: fn
   });
   expect(fn).not.toHaveBeenCalled();
 });
 
 it("must not react if it's ignore target", async () => {
-  const now = new Date();
-  const createdAt = new Date();
-  createdAt.setSeconds(createdAt.getSeconds() - 10);
-
   const responder = new DeletionRepeater(
     (content) => content === 'Wall Is Stop',
-    () => now
+    deletedDate
   );
   const fn = vi.fn();
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Stop',
-    createdAt: createdAt,
+    createdAt: createdDate(),
     sendEphemeralToSameChannel: fn
   });
   expect(fn).not.toHaveBeenCalled();
 });
 
 it("must react if it's not ignore target", async () => {
-  const now = new Date();
-  const createdAt = new Date();
-  createdAt.setSeconds(createdAt.getSeconds() - 10);
-
   const responder = new DeletionRepeater(
     (content) => content === 'Wall Is Stop',
-    () => now
+    deletedDate
   );
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Not Stop',
-    createdAt: createdAt,
+    createdAt: createdDate(),
     sendEphemeralToSameChannel: (message) => {
       expect(message)
         .toEqual(`Babaさん、メッセージを削除しましたね？私は見ていましたよ。内容も知っています。
@@ -89,18 +84,11 @@ Wall Is Not Stop
 });
 
 it("react to deleted message if it's too fast", async () => {
-  const now = new Date();
-  const createdAt = new Date();
-  createdAt.setSeconds(now.getSeconds() - 1);
-
-  const responder = new DeletionRepeater(
-    () => false,
-    () => now
-  );
+  const responder = new DeletionRepeater(() => false, fastDeletedDate);
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Stop',
-    createdAt: createdAt,
+    createdAt: createdDate(),
     sendEphemeralToSameChannel: (message) => {
       expect(message)
         .toEqual(`Babaさんの恐ろしく早いメッセージの削除。私じゃなきゃ見逃していましたよ。

--- a/packages/bot/src/service/deletion-repeater.test.ts
+++ b/packages/bot/src/service/deletion-repeater.test.ts
@@ -4,13 +4,17 @@ import { DeletionRepeater } from './deletion-repeater.js';
 
 it('react to deleted message', async () => {
   const now = new Date();
-  now.setSeconds(now.getSeconds() - 10);
+  const createdAt = new Date();
+  createdAt.setSeconds(createdAt.getSeconds() - 10);
 
-  const responder = new DeletionRepeater(() => false);
+  const responder = new DeletionRepeater(
+    () => false,
+    () => now
+  );
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Stop',
-    createdAt: now,
+    createdAt: createdAt,
     sendEphemeralToSameChannel: (message) => {
       expect(message)
         .toEqual(`Babaさん、メッセージを削除しましたね？私は見ていましたよ。内容も知っています。
@@ -24,14 +28,18 @@ Wall Is Stop
 
 it('must not react', async () => {
   const now = new Date();
-  now.setSeconds(now.getSeconds() - 10);
+  const createdAt = new Date();
+  createdAt.setSeconds(now.getSeconds() - 10);
 
-  const responder = new DeletionRepeater(() => false);
+  const responder = new DeletionRepeater(
+    () => false,
+    () => now
+  );
   const fn = vi.fn();
   await responder.on('CREATE', {
     author: 'Baba',
     content: 'Wall Is Not Stop',
-    createdAt: now,
+    createdAt: createdAt,
     sendEphemeralToSameChannel: fn
   });
   expect(fn).not.toHaveBeenCalled();
@@ -39,16 +47,18 @@ it('must not react', async () => {
 
 it("must not react if it's ignore target", async () => {
   const now = new Date();
-  now.setSeconds(now.getSeconds() - 10);
+  const createdAt = new Date();
+  createdAt.setSeconds(createdAt.getSeconds() - 10);
 
   const responder = new DeletionRepeater(
-    (content) => content === 'Wall Is Stop'
+    (content) => content === 'Wall Is Stop',
+    () => now
   );
   const fn = vi.fn();
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Stop',
-    createdAt: now,
+    createdAt: createdAt,
     sendEphemeralToSameChannel: fn
   });
   expect(fn).not.toHaveBeenCalled();
@@ -56,15 +66,17 @@ it("must not react if it's ignore target", async () => {
 
 it("must react if it's not ignore target", async () => {
   const now = new Date();
-  now.setSeconds(now.getSeconds() - 10);
+  const createdAt = new Date();
+  createdAt.setSeconds(createdAt.getSeconds() - 10);
 
   const responder = new DeletionRepeater(
-    (content) => content === 'Wall Is Stop'
+    (content) => content === 'Wall Is Stop',
+    () => now
   );
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Not Stop',
-    createdAt: now,
+    createdAt: createdAt,
     sendEphemeralToSameChannel: (message) => {
       expect(message)
         .toEqual(`Babaさん、メッセージを削除しましたね？私は見ていましたよ。内容も知っています。
@@ -78,13 +90,17 @@ Wall Is Not Stop
 
 it("react to deleted message if it's too fast", async () => {
   const now = new Date();
-  now.setSeconds(now.getSeconds() - 1);
+  const createdAt = new Date();
+  createdAt.setSeconds(now.getSeconds() - 1);
 
-  const responder = new DeletionRepeater(() => false);
+  const responder = new DeletionRepeater(
+    () => false,
+    () => now
+  );
   await responder.on('DELETE', {
     author: 'Baba',
     content: 'Wall Is Stop',
-    createdAt: now,
+    createdAt: createdAt,
     sendEphemeralToSameChannel: (message) => {
       expect(message)
         .toEqual(`Babaさんの恐ろしく早いメッセージの削除。私じゃなきゃ見逃していましたよ。

--- a/packages/bot/src/service/deletion-repeater.ts
+++ b/packages/bot/src/service/deletion-repeater.ts
@@ -14,6 +14,11 @@ export interface DeletionObservable {
   readonly content: string;
 
   /**
+   * メッセージの送信日時
+   */
+  readonly createdAt: Date;
+
+  /**
    * すぐ消えてしまう `message` のメッセージをこのメッセージと同じチャンネルに送信する。
    *
    * @param message - 送信するメッセージのテキスト

--- a/packages/bot/src/service/deletion-repeater.ts
+++ b/packages/bot/src/service/deletion-repeater.ts
@@ -45,8 +45,18 @@ export class DeletionRepeater<M extends DeletionObservable>
     if (event !== 'DELETE') {
       return;
     }
-    const { author, content } = message;
+    const { author, content, createdAt } = message;
     if (this.isIgnoreTarget(content)) {
+      return;
+    }
+
+    const now = new Date();
+    const diff = now.getTime() - createdAt.getTime();
+    if (diff <= 3) {
+      await message.sendEphemeralToSameChannel(`${author}さんの恐ろしく早いメッセージの削除。私じゃなきゃ見逃していましたよ。
+      \`\`\`
+      ${content}
+      \`\`\``);
       return;
     }
 

--- a/packages/bot/src/service/deletion-repeater.ts
+++ b/packages/bot/src/service/deletion-repeater.ts
@@ -26,6 +26,13 @@ export interface DeletionObservable {
    */
   sendEphemeralToSameChannel(message: string): Promise<void>;
 }
+/**
+ * 現在時刻を取得するための関数の型
+ *
+ * @returns `Date`オブジェクト
+ */
+
+export type GetNow = () => Date;
 
 /**
  * メッセージの削除を検知して、その内容と作者を復唱する。
@@ -41,7 +48,7 @@ export class DeletionRepeater<M extends DeletionObservable>
    */
   constructor(
     private readonly isIgnoreTarget: (content: string) => boolean,
-    private readonly getNow: () => Date
+    private readonly getNow: GetNow
   ) {}
 
   async on(event: MessageEvent, message: M): Promise<void> {

--- a/packages/bot/src/service/deletion-repeater.ts
+++ b/packages/bot/src/service/deletion-repeater.ts
@@ -54,9 +54,9 @@ export class DeletionRepeater<M extends DeletionObservable>
     const diff = now.getTime() - createdAt.getTime();
     if (diff <= 3) {
       await message.sendEphemeralToSameChannel(`${author}さんの恐ろしく早いメッセージの削除。私じゃなきゃ見逃していましたよ。
-      \`\`\`
-      ${content}
-      \`\`\``);
+\`\`\`
+${content}
+\`\`\``);
       return;
     }
 

--- a/packages/bot/src/service/deletion-repeater.ts
+++ b/packages/bot/src/service/deletion-repeater.ts
@@ -51,7 +51,7 @@ export class DeletionRepeater<M extends DeletionObservable>
     }
 
     const now = new Date();
-    const diff = now.getTime() - createdAt.getTime();
+    const diff = now.getSeconds() - createdAt.getSeconds();
     if (diff <= 3) {
       await message.sendEphemeralToSameChannel(`${author}さんの恐ろしく早いメッセージの削除。私じゃなきゃ見逃していましたよ。
 \`\`\`

--- a/packages/bot/src/service/deletion-repeater.ts
+++ b/packages/bot/src/service/deletion-repeater.ts
@@ -39,7 +39,10 @@ export class DeletionRepeater<M extends DeletionObservable>
    * メッセージを無視するかどうかを判定する述語。
    * この述語がtrueを返した場合、内容を復唱しない。
    */
-  constructor(private readonly isIgnoreTarget: (content: string) => boolean) {}
+  constructor(
+    private readonly isIgnoreTarget: (content: string) => boolean,
+    private readonly getNow: () => Date
+  ) {}
 
   async on(event: MessageEvent, message: M): Promise<void> {
     if (event !== 'DELETE') {
@@ -50,8 +53,7 @@ export class DeletionRepeater<M extends DeletionObservable>
       return;
     }
 
-    const now = new Date();
-    const diff = now.getSeconds() - createdAt.getSeconds();
+    const diff = this.getNow().getSeconds() - createdAt.getSeconds();
     if (diff <= 3) {
       await message.sendEphemeralToSameChannel(`${author}さんの恐ろしく早いメッセージの削除。私じゃなきゃ見逃していましたよ。
 \`\`\`

--- a/packages/bot/src/service/index.ts
+++ b/packages/bot/src/service/index.ts
@@ -30,6 +30,7 @@ import type { EntranceOutput, StandardOutput } from './output.js';
 import { WelcomeMessage } from './welcome-message.js';
 
 const stfuIgnorePredicate = (content: string): boolean => content === '!stfu';
+const getNow = (): Date => new Date();
 
 export const allMessageEventResponder = (
   repo: TypoRepository,
@@ -38,7 +39,7 @@ export const allMessageEventResponder = (
   composeMessageEventResponders<
     DeletionObservable & TypoObservable & BoldItalicCop & EmojiSeqObservable
   >(
-    new DeletionRepeater(stfuIgnorePredicate),
+    new DeletionRepeater(stfuIgnorePredicate, getNow),
     new TypoRecorder(repo),
     new BoldItalicCopReporter(),
     new EmojiSeqReact(sequencesYaml)

--- a/packages/bot/src/service/index.ts
+++ b/packages/bot/src/service/index.ts
@@ -17,7 +17,8 @@ import {
 } from './command/typo-record.js';
 import {
   type DeletionObservable,
-  DeletionRepeater
+  DeletionRepeater,
+  type GetNow
 } from './deletion-repeater.js';
 import { DifferenceDetector } from './difference-detector.js';
 import { EmojiLog } from './emoji-log.js';
@@ -30,11 +31,11 @@ import type { EntranceOutput, StandardOutput } from './output.js';
 import { WelcomeMessage } from './welcome-message.js';
 
 const stfuIgnorePredicate = (content: string): boolean => content === '!stfu';
-const getNow = (): Date => new Date();
 
 export const allMessageEventResponder = (
   repo: TypoRepository,
-  sequencesYaml: string
+  sequencesYaml: string,
+  getNow: GetNow
 ) =>
   composeMessageEventResponders<
     DeletionObservable & TypoObservable & BoldItalicCop & EmojiSeqObservable


### PR DESCRIPTION
close #1247

<!--
    このプルリクエストに関連し、マージ時に自動的にクローズしたいIssueの番号を記載します。
    複数のIssueを記載する場合は、改行で区切ってください。
    例:
    close #1
    close #2
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### Type of Change:
- feat(interface)!: `DeletionObservable`インターフェイスへの破壊的変更
- fix(type)!: `DeletionObservable`の変更に起因する型エラーの修正
- fix(test)!: `DeletionObservable`の変更に起因するテストケースのエラーを修正
- feat: メッセージを変化させるロジックを追加
- test: 追加したロジックのテストケースを追加

<!--
    案を実現するためにどういうタイプの変更を行ったのか
    e.g. 修正(fix), 新規追加(feat), 破壊的変更　など
-->

### Details of implementation (実施内容)
実装したい機能を実現するために必要なフィールドを追加しました。このために発生したエラーを修正しました。
特殊メッセージを送信する条件を満たしているかを確認し、満たしている場合メッセージを切り替える処理を追加しました。また、特殊メッセージを送信する条件を満たしたときにメッセージが切り替わっていることを確認するテストを追加しました。


### Additional Information (追加情報)
