### PR TITLE
chore: サポートする Node.js のバージョンを `v20` に固定

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -167,7 +167,7 @@ OreOreBot2 (@oreorebot2/common)
 
 - Git
 - FFmpeg ([音楽再生系の機能](#音楽再生系の機能)で必要です)
-- Node.js v18.x 以上
+- Node.js v20.x 以上
 - pnpm v8
 
 #### コーディング規約

--- a/packages/bot/README.md
+++ b/packages/bot/README.md
@@ -8,7 +8,7 @@ Discord Bot 本体を提供するパッケージ。
 
 - git
 - ffmpeg
-- Node.js v18.x 以上
+- Node.js v20.x 以上
 - pnpm v8
 
 ## 環境変数

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -17,7 +17,7 @@
     "lint-staged": "lint-staged"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "@discordjs/opus": "^0.9.0",


### PR DESCRIPTION
### Details of implementation (実施内容)

OreOreBot2 がサポートする Node.js バージョンを v20 (現行の最新 LTS) に固定しました.