### PR TITLE
fix(docker): apt パッケージのバージョン指定を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /app
 
 # Sentry に必要なパッケージ
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libssl-dev=3.0.2-0ubuntu1.12 ca-certificates=20230311ubuntu0.22.04.1 \
+    && apt-get install -y --no-install-recommends libssl-dev=3.0.2-0ubuntu1.13 ca-certificates=20230311ubuntu0.22.04.1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Type of Change:

Dockerfile の修正

### Details of implementation (実施内容)

[リリース CI のエラーログ](https://github.com/approvers/OreOreBot2/actions/runs/7772156166/job/21194261789) に基づいて, apt パッケージのバージョン指定を修正しました. ローカルで `docker build -t oreorebot2 .` が通ることは確認しています.
