### PR TITLE
fix: Add command runner into registry

### DIFF
--- a/packages/bot/src/server/index.ts
+++ b/packages/bot/src/server/index.ts
@@ -42,7 +42,7 @@ import { membersRepositoryKey } from '../model/member.js';
 import { randomGeneratorKey } from '../model/random-generator.js';
 import { roleRepositoryKey } from '../model/role.js';
 import { voiceRoomControllerKey } from '../model/voice-room-controller.js';
-import { CommandRunner } from '../runner/command.js';
+import { CommandRunner, commandRunnerKey } from '../runner/command.js';
 import {
   EmojiResponseRunner,
   MessageResponseRunner,
@@ -164,6 +164,7 @@ if (features.includes('MESSAGE_UPDATE')) {
 
 const commandProxy = new DiscordCommandProxy(client, PREFIX);
 const commandRunner = new CommandRunner(commandProxy);
+registry.add(commandRunnerKey, commandRunner);
 const stats = new DiscordMemberStats(client, GUILD_ID as Snowflake);
 registry.add(memberStatsKey, stats);
 registry.add(membersRepositoryKey, stats);


### PR DESCRIPTION
### Type of Change:

バグ修正

### Cause of the Problem (問題の原因)

依存関係レジストリにコマンドランナーを追加し忘れていた. ヘルプコマンドが他のコマンドを取得するためにコマンドランナーにアクセスしていたが, そこでの参照の解決に失敗して異常終了していた.
