### PR TITLE
fix: Fix bun version of base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mwader/static-ffmpeg:6.1.1 as ffmpeg
 
-FROM oven/bun:1-slim as build
+FROM oven/bun:1.0.35-slim as build
 ARG GIT_TAG
 SHELL ["/bin/bash", "-c"]
 WORKDIR /src


### PR DESCRIPTION
### Type of Change:

Dockerfile の修正

### Dealing with Problems (問題への対処)

Bun が semver へ厳密に従っておらずロックファイルの生成結果が整合しなくなることがあった. ベースイメージのバージョンがメジャーバージョンのみだったが, この問題への対処としてバージョン指定をパッチまで固定した.
